### PR TITLE
fix: 로그인 토큰 저장소 변경 

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -1,12 +1,12 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import axios from 'axios';
-import { useCallback, useState } from 'react';
+import { useCallback, useContext, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import useSWR from 'swr';
 
 import Logo from '@/assets/Logo.svg';
 import VisibilityOn from '@/assets/VisibilityOn.svg';
+import { MainContext } from '@/store';
 import { tokenType } from '@/types/token.interface';
 interface StyledPasswordIconProps {
   password: string;
@@ -14,11 +14,10 @@ interface StyledPasswordIconProps {
 
 export default function LoginForm() {
   const baseUrl = import.meta.env.VITE_BASE_URL as string;
+  const { setLoginToken } = useContext(MainContext);
   const [username, setUsername] = useState<string>('');
   const [password, setPassword] = useState<string>('');
   const [showPassword, setShowPassword] = useState<boolean>(false);
-
-  const { mutate } = useSWR<tokenType>('getToken');
 
   const navigate = useNavigate();
 
@@ -40,8 +39,7 @@ export default function LoginForm() {
           '',
           { headers }
         );
-
-        mutate(response.data);
+        setLoginToken(response.data.accessToken);
         window.localStorage.setItem('token', response.data.accessToken);
         window.localStorage.setItem('refreshToken', response.data.refreshToken);
 
@@ -51,7 +49,7 @@ export default function LoginForm() {
         console.error('error');
       }
     },
-    [username, password, navigate, mutate, baseUrl]
+    [username, password, navigate, baseUrl, setLoginToken]
   );
 
   return (

--- a/src/components/common/DeleteModal/index.tsx
+++ b/src/components/common/DeleteModal/index.tsx
@@ -25,7 +25,7 @@ export default function DeleteModalContainer({
 
   const handleDeleteClick = async () => {
     const headers = {
-      Authorization: `Bearer ${loginToken.accessToken}`,
+      Authorization: `Bearer ${loginToken}`,
       'Content-Type': 'application/json',
     };
 
@@ -44,7 +44,7 @@ export default function DeleteModalContainer({
     }
 
     if (pathname === '/media') {
-      deleteLink(id, loginToken.accessToken);
+      deleteLink(id, loginToken);
     }
 
     setDeleteModalOpen(false);

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,14 +1,16 @@
 import { Avatar } from '@chakra-ui/react';
 import styled from '@emotion/styled';
-import { useCallback, useState } from 'react';
+import { useCallback, useContext, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import Logo from '@/assets/Logo.svg';
+import { MainContext } from '@/store';
 import { category, userName } from '@/utils/constants/header';
 import { categoryType } from '@/utils/constants/header';
 
 export default function Header() {
   const navigate = useNavigate();
+  const { loginToken } = useContext(MainContext);
   const { pathname } = useLocation();
   const [clickedIdNum, setClickedIdNum] = useState<number>(2);
 
@@ -26,6 +28,10 @@ export default function Header() {
 
   if (pathname === '/') {
     return null;
+  }
+
+  if (loginToken === '') {
+    navigate('/');
   }
 
   return (

--- a/src/hooks/useCategory.tsx
+++ b/src/hooks/useCategory.tsx
@@ -12,10 +12,7 @@ export default function useCategory() {
     data: categoryList,
     mutate,
     error,
-  } = useSWR<CategoryListResponseDTO, Error>(
-    [loginToken.accessToken],
-    getCategoryList
-  );
+  } = useSWR<CategoryListResponseDTO, Error>([loginToken], getCategoryList);
 
   return {
     categoryListData: categoryList,

--- a/src/hooks/useRecord.tsx
+++ b/src/hooks/useRecord.tsx
@@ -13,7 +13,7 @@ export default function useRecord(category?: string) {
     mutate,
     error,
   } = useSWR<recordListType, Error>(
-    ['record-templates', loginToken.accessToken],
+    ['record-templates', loginToken],
     recordListFetcher
   );
 

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -5,15 +5,13 @@ import React, {
   useEffect,
   useState,
 } from 'react';
-import useSWR from 'swr';
 
 import { Question } from '@/types/question.interface';
-import { tokenType } from '@/types/token.interface';
 import { categoryList, categoryListType } from '@/utils/constants/categoryList';
 import { mediaList, mediaListType } from '@/utils/constants/mediaList';
 
 type ContextType = {
-  loginToken: tokenType;
+  loginToken: string;
   recordModalOpen: boolean;
   mediaModalOpen: boolean;
   addMediaItem: (mediaItemWithoutId: Omit<mediaListType, 'id'>) => void;
@@ -31,10 +29,11 @@ type ContextType = {
   setStoredCategoryList: (storedCategoryList: categoryListType[]) => void;
   selectedRecordCard: string;
   setSelectedRecordCard: Dispatch<SetStateAction<string>>;
+  setLoginToken: Dispatch<SetStateAction<string>>;
 };
 
 export const MainContext = React.createContext<ContextType>({
-  loginToken: { accessToken: '', refreshToken: '', message: '' },
+  loginToken: '',
 
   mediaList: [],
   questionList: [],
@@ -52,23 +51,19 @@ export const MainContext = React.createContext<ContextType>({
   addMediaItem: () => {},
   selectedRecordCard: '',
   setSelectedRecordCard: () => {},
+  setLoginToken: () => {},
 });
 
 export default function MainContextProvider(props: {
   children: React.ReactNode;
 }) {
-  const { data: tokenData } = useSWR<tokenType>('getToken');
-  const [loginToken, setLoginToken] = useState<tokenType>({
-    accessToken: '',
-    refreshToken: '',
-    message: '',
-  });
+  const [loginToken, setLoginToken] = useState('');
 
   useEffect(() => {
-    if (tokenData) {
-      setLoginToken(tokenData);
+    if (localStorage.getItem('token')) {
+      setLoginToken(localStorage.getItem('token')!);
     }
-  }, [tokenData]);
+  }, [setLoginToken]);
 
   const [recordModalState, setRecordModalState] = useState(false);
   const [mediaModalState, setMediaModalState] = useState(false);
@@ -100,7 +95,7 @@ export default function MainContextProvider(props: {
   );
 
   const contextValue: ContextType = {
-    loginToken: loginToken,
+    loginToken,
     mediaList: storedMediaList,
     questionList: storedQuestionList,
     deleteMediaItem: deleteMediaItemHandler,
@@ -116,6 +111,7 @@ export default function MainContextProvider(props: {
     storedCategoryList,
     selectedRecordCard,
     setSelectedRecordCard,
+    setLoginToken,
   };
 
   return (


### PR DESCRIPTION
## 💡 이슈 번호

close #67

## 📖 작업 내용

- [] 기존의 context store에만 저장해둔 로그인 토큰을 새로고침이후에도 사용가능하도록 로컬저장소에도 저장


## ✅ PR 포인트

이제 로그인 토큰 사용할때 loginToken.accessToken 말고 그냥 loginToken 가져와서 사용하시면 됩니다

## 📸 스크린샷
![PieHealthcare - Chrome 2023-08-02 16-30-51](https://github.com/pie-sfac/5-17-smokedDuck/assets/104823768/6482cac6-8876-441d-ae32-7e48583621fa)