### PR TITLE
feat: 기록 템플릿 생성 api 연동 (처치)

### DIFF
--- a/src/apis/Template.ts
+++ b/src/apis/Template.ts
@@ -1,16 +1,23 @@
 import axios, { AxiosResponse } from 'axios';
 
+import { Questions } from '@/types/question.interface';
 import { CreateTemplateResponse } from '@/types/template.interface';
-import { Template } from '@/types/template.interface';
+
+type NewTemplateContent = {
+  questions: Questions[];
+  category?: '' | 'INTERVIEW' | 'TREATMENT' | undefined;
+  title?: string | undefined;
+  description?: string | undefined;
+};
 
 const BASE_URL: string = import.meta.env.VITE_BASE_URL as string;
 const TEMPLATE_URL = 'record-templates';
 
-const requestUrl = `${BASE_URL}/${TEMPLATE_URL}`;
+export const requestUrl = `${BASE_URL}/${TEMPLATE_URL}`;
 
 export async function createTemplate(
   loginToken: string,
-  templateContent: Template | undefined
+  templateContent: NewTemplateContent
 ) {
   try {
     const response: AxiosResponse<CreateTemplateResponse> = await axios.post(

--- a/src/apis/Template.ts
+++ b/src/apis/Template.ts
@@ -1,0 +1,30 @@
+import axios, { AxiosResponse } from 'axios';
+
+import { CreateTemplateResponse } from '@/types/template.interface';
+import { Template } from '@/types/template.interface';
+
+const BASE_URL: string = import.meta.env.VITE_BASE_URL as string;
+const TEMPLATE_URL = 'record-templates';
+
+const requestUrl = `${BASE_URL}/${TEMPLATE_URL}`;
+
+export async function createTemplate(
+  loginToken: string,
+  templateContent: Template | undefined
+) {
+  try {
+    const response: AxiosResponse<CreateTemplateResponse> = await axios.post(
+      requestUrl,
+      templateContent,
+      {
+        headers: {
+          Authorization: `Bearer ${loginToken}`,
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+    return response.data;
+  } catch (error) {
+    console.error(error);
+  }
+}

--- a/src/apis/record.ts
+++ b/src/apis/record.ts
@@ -4,14 +4,13 @@ import { recordListResponseType } from '@/types/recordList.interface';
 
 const baseUrl = import.meta.env.VITE_BASE_URL as string;
 
-export function recordListFetcher([url, tokenData]: string[]) {
+export async function recordListFetcher([url, tokenData]: string[]) {
   const headers = {
     Authorization: `Bearer ${tokenData}`,
     'Content-Type': 'application/json',
   };
-  return axios
-    .get<recordListResponseType>(`${baseUrl}/${url}`, {
-      headers,
-    })
-    .then(res => res.data.templates);
+  const res = await axios.get<recordListResponseType>(`${baseUrl}/${url}`, {
+    headers,
+  });
+  return res.data.templates;
 }

--- a/src/components/Question/QuestionFooter.tsx
+++ b/src/components/Question/QuestionFooter.tsx
@@ -1,15 +1,40 @@
 import { Switch } from '@chakra-ui/react';
 import styled from '@emotion/styled';
+import { useState } from 'react';
 import { RxTrash } from 'react-icons/rx';
 import { VscTriangleDown, VscTriangleUp } from 'react-icons/vsc';
+interface AddedSelection {
+  _id: number;
+  selectionName: string;
+}
 
-export default function QuestionFooter() {
+type QuestionFooterProps = {
+  order: number;
+  onChange: (
+    order: number,
+    id: string,
+    value: string | AddedSelection[] | boolean
+  ) => void;
+};
+
+export default function QuestionFooter({
+  order,
+  onChange,
+}: QuestionFooterProps) {
+  const [isRequired, setIsRequired] = useState(false);
   return (
     <QuestionFooterContainer>
       <EssentialContainer>
         <label htmlFor="essential">필수</label>
         &nbsp;
-        <Switch id={'essential'} size="sm" />
+        <Switch
+          id={'essential'}
+          size="sm"
+          onChange={() => {
+            setIsRequired(prevIsRequired => !prevIsRequired);
+            onChange(order, 'required', isRequired ? false : true);
+          }}
+        />
       </EssentialContainer>
       <MoveContainer>
         이동 &nbsp;

--- a/src/components/Question/QuestionHeader.tsx
+++ b/src/components/Question/QuestionHeader.tsx
@@ -1,21 +1,34 @@
 import styled from '@emotion/styled';
+import { useState } from 'react';
 
 import QuestionMark from '@/assets/QuestionMark.svg';
+interface AddedSelection {
+  _id: number;
+  selectionName: string;
+}
 
 type QuestionHeaderProps = {
-  id: number;
+  order: number;
   title: string;
   tagName: string;
+  onChange: (
+    order: number,
+    id: string,
+    value: string | AddedSelection[] | boolean
+  ) => void;
 };
 export default function QuestionHeader({
-  id,
+  order,
   title,
   tagName,
+  onChange,
 }: QuestionHeaderProps) {
+  const [isAllowMultiple, setIsAllowMultiple] = useState(false);
+
   return (
     <HeaderContainer>
       <TitleContainer>
-        {id < 10 ? '0' + id : id}. {title}
+        {order < 10 ? '0' + order : order}. {title}
         <TagNameContainer>
           <StyledTagName
             style={{
@@ -30,13 +43,23 @@ export default function QuestionHeader({
       </TitleContainer>
       {title === '텍스트' && (
         <OptionContainer>
-          <input type="radio" name={`answerType${id}`} id="shortAnswer" />
+          <input
+            type="radio"
+            name={`answerType${order}`}
+            id="shortAnswer"
+            onChange={() => onChange(order, 'paragraph', false)}
+          />
           &nbsp;
           <label htmlFor="shortAnswer" style={{ fontSize: '0.7rem' }}>
             단답형
           </label>
           &nbsp;
-          <input type="radio" name={`answerType${id}`} id="longAnswer" />
+          <input
+            type="radio"
+            name={`answerType${order}`}
+            id="longAnswer"
+            onChange={() => onChange(order, 'paragraph', true)}
+          />
           &nbsp;
           <label htmlFor="longAnswer" style={{ fontSize: '0.7rem' }}>
             장문형
@@ -47,8 +70,12 @@ export default function QuestionHeader({
         <OptionContainer>
           <input
             type="checkbox"
-            name={`allowDuplicates${id}`}
+            name={`allowDuplicates${order}`}
             id="allowDuplicates"
+            onChange={() => {
+              setIsAllowMultiple(prevIsAllowMultiple => !prevIsAllowMultiple);
+              onChange(order, 'allowMultiple', isAllowMultiple ? false : true);
+            }}
           />
           &nbsp;
           <label htmlFor="allowDuplicates" style={{ fontSize: '0.7rem' }}>

--- a/src/components/Question/index.tsx
+++ b/src/components/Question/index.tsx
@@ -3,19 +3,39 @@ import styled from '@emotion/styled';
 import QuestionContent from './QuestionContent';
 import QuestionFooter from './QuestionFooter';
 import QuestionHeader from './QuestionHeader';
-
-interface QuestionProps {
+interface AddedSelection {
   _id: number;
+  selectionName: string;
+}
+interface QuestionProps {
+  order: number;
   title: string;
   tagName: string;
+  onChange: (
+    order: number,
+    id: string,
+    value: string | AddedSelection[] | boolean
+  ) => void;
 }
 
-export default function Question({ _id, title, tagName }: QuestionProps) {
+export default function Question({
+  order,
+  title,
+  tagName,
+  onChange,
+}: QuestionProps) {
   return (
     <QuestionContainer>
-      <QuestionHeader id={_id} title={title} tagName={tagName} />
-      {tagName === '기본' && <QuestionContent title={title} />}
-      <QuestionFooter />
+      <QuestionHeader
+        order={order}
+        title={title}
+        tagName={tagName}
+        onChange={onChange}
+      />
+      {tagName === '기본' && (
+        <QuestionContent title={title} order={order} onChange={onChange} />
+      )}
+      <QuestionFooter order={order} onChange={onChange} />
     </QuestionContainer>
   );
 }

--- a/src/components/Template/TemplateContent.tsx
+++ b/src/components/Template/TemplateContent.tsx
@@ -1,14 +1,18 @@
 import { useContext } from 'react';
 
 import { MainContext } from '@/store';
+import { Questions } from '@/types/question.interface';
 
-import TemplateFooter from './TemplateFooter';
 import TemplateQuestionSelections from './TemplateQuestionSelections';
 import TemplateSelectedQuestionContainer from './TemplateSelectedQuestionContainer';
 import TemplateSelections from './TemplateSelections';
 import TemplateSubHeader from './TemplateSubHeader';
 
-export default function TemplateContent() {
+type TemplateContentProps = {
+  onChange: (id: string, value: string | Questions[]) => void;
+};
+
+export default function TemplateContent({ onChange }: TemplateContentProps) {
   const { selectedTemplateTitle } = useContext(MainContext);
 
   return (
@@ -17,10 +21,9 @@ export default function TemplateContent() {
         <TemplateSelections />
       ) : (
         <>
-          <TemplateSubHeader />
+          <TemplateSubHeader onChange={onChange} />
           <TemplateQuestionSelections />
           <TemplateSelectedQuestionContainer />
-          <TemplateFooter />
         </>
       )}
     </div>

--- a/src/components/Template/TemplateFooter.tsx
+++ b/src/components/Template/TemplateFooter.tsx
@@ -3,17 +3,15 @@ import styled from '@emotion/styled';
 import { useContext } from 'react';
 
 import { MainContext } from '@/store';
-import { Questions } from '@/types/question.interface';
 
 type TemplateFooterProps = {
-  onChange: (id: string, value: string | Questions[]) => void;
+  handleClickedSaveButton: () => Promise<void>;
 };
-export default function TemplateFooter({ onChange }: TemplateFooterProps) {
-  const { questionList } = useContext(MainContext);
 
-  const handleClickedSaveButton = () => {
-    onChange('question', questionList);
-  };
+export default function TemplateFooter({
+  handleClickedSaveButton,
+}: TemplateFooterProps) {
+  const { questionList } = useContext(MainContext);
 
   return (
     <FooterContainer>

--- a/src/components/Template/TemplateFooter.tsx
+++ b/src/components/Template/TemplateFooter.tsx
@@ -3,9 +3,17 @@ import styled from '@emotion/styled';
 import { useContext } from 'react';
 
 import { MainContext } from '@/store';
+import { Questions } from '@/types/question.interface';
 
-export default function TemplateFooter() {
+type TemplateFooterProps = {
+  onChange: (id: string, value: string | Questions[]) => void;
+};
+export default function TemplateFooter({ onChange }: TemplateFooterProps) {
   const { questionList } = useContext(MainContext);
+
+  const handleClickedSaveButton = () => {
+    onChange('question', questionList);
+  };
 
   return (
     <FooterContainer>
@@ -17,6 +25,7 @@ export default function TemplateFooter() {
         }}
         borderRadius={'20px 20px 20px 20px'}
         isDisabled={questionList.length < 1 ? true : false}
+        onClick={handleClickedSaveButton}
       >
         저장
       </Button>

--- a/src/components/Template/TemplateFooter.tsx
+++ b/src/components/Template/TemplateFooter.tsx
@@ -3,15 +3,17 @@ import styled from '@emotion/styled';
 import { useContext } from 'react';
 
 import { MainContext } from '@/store';
+import { Questions } from '@/types/question.interface';
 
 type TemplateFooterProps = {
-  handleClickedSaveButton: () => Promise<void>;
+  onChange: (id: string, value: string | Questions[]) => void;
 };
-
-export default function TemplateFooter({
-  handleClickedSaveButton,
-}: TemplateFooterProps) {
+export default function TemplateFooter({ onChange }: TemplateFooterProps) {
   const { questionList } = useContext(MainContext);
+
+  const handleClickedSaveButton = () => {
+    onChange('question', questionList);
+  };
 
   return (
     <FooterContainer>

--- a/src/components/Template/TemplateQuestionSelections.tsx
+++ b/src/components/Template/TemplateQuestionSelections.tsx
@@ -61,6 +61,7 @@ export default function TemplateQuestionSelections() {
             description={'텍스트 형식의 답변을 입력하는 문항입니다.'}
             tagName={'기본'}
             margin={'0.4rem'}
+            type={'TEXT'}
           />
           <QuestionBox
             image={Media}
@@ -68,12 +69,14 @@ export default function TemplateQuestionSelections() {
             description={'이미지 혹은 영상을 답변으로 첨부하는 문항입니다. '}
             tagName={'기본'}
             margin={'0.4rem'}
+            type={'MEDIA'}
           />
           <QuestionBox
             image={Selections}
             title={'선택형'}
             description={'보기 중 선택해서 답변하는 문항입니다.'}
             tagName={'기본'}
+            type={'SELECT'}
           />
         </QuestionBoxContainer>
       )}
@@ -85,6 +88,7 @@ export default function TemplateQuestionSelections() {
             description={'회원의 통증 정도를 선택하는 문항입니다.'}
             tagName={'전문'}
             margin={'0.4rem'}
+            type={'PAIN_HSTRY'}
           />
           <QuestionBox
             image={Condition}
@@ -92,6 +96,7 @@ export default function TemplateQuestionSelections() {
             description={'회원의 컨디션 정도를 선택하는 문항입니다.'}
             tagName={'전문'}
             margin={'0.4rem'}
+            type={'CONDITION'}
           />
           <QuestionBox
             image={PainQuestion}
@@ -100,6 +105,7 @@ export default function TemplateQuestionSelections() {
               '통증 부위, 유형, 정도, 빈도, 기간을 작성할 수 있는 문항입니다.'
             }
             tagName={'전문'}
+            type={'PAIN_INTV'}
           />
         </QuestionBoxContainer>
       )}

--- a/src/components/Template/TemplateSelectedQuestionContainer.tsx
+++ b/src/components/Template/TemplateSelectedQuestionContainer.tsx
@@ -6,8 +6,27 @@ import { MainContext } from '@/store';
 
 import Question from '../Question';
 
+interface AddedSelection {
+  _id: number;
+  selectionName: string;
+}
+
 export default function TemplateSelectedQuestionContainer() {
-  const { questionList } = useContext(MainContext);
+  const { questionList, setQuestionList } = useContext(MainContext);
+
+  const handleQuestionContent = (
+    order: number,
+    id: string,
+    value: string | AddedSelection[] | boolean
+  ) => {
+    const updatedQuestion = questionList.map(question =>
+      question.order === order
+        ? { ...question, [id === 'title' ? question.title : id]: value }
+        : question
+    );
+
+    setQuestionList(updatedQuestion);
+  };
 
   return (
     <ContentContainer
@@ -28,10 +47,11 @@ export default function TemplateSelectedQuestionContainer() {
       ) : (
         questionList.map(question => (
           <Question
-            key={question._id}
-            _id={question._id}
-            title={question.questionTitle}
+            key={question.order}
+            order={question.order}
+            title={question.title}
             tagName={question.tagName}
+            onChange={handleQuestionContent}
           />
         ))
       )}

--- a/src/components/Template/TemplateSelections.tsx
+++ b/src/components/Template/TemplateSelections.tsx
@@ -1,28 +1,22 @@
 import styled from '@emotion/styled';
-import { useContext } from 'react';
 
 import Template from '@/assets/Template.svg';
-import { MainContext } from '@/store';
 
 import SelectionBox from '../Common/SelectionBox';
 
 export default function TemplateSelections() {
-  const { setSelectedTemplateTitle } = useContext(MainContext);
-
   return (
     <SelectionBoxContainer>
       <SelectionBox
         title={'문진 템플릿'}
         titleDescription={'첫 방문 또는 회원 현재 상태를 체크 합니다.'}
         image={Template}
-        onClick={() => setSelectedTemplateTitle('문진 템플릿')}
       />
 
       <SelectionBox
         title={'처치 템플릿'}
         titleDescription={'수업 시, 작성합니다.'}
         image={Template}
-        onClick={() => setSelectedTemplateTitle('처치 템플릿')}
       />
     </SelectionBoxContainer>
   );

--- a/src/components/Template/TemplateSubHeader.tsx
+++ b/src/components/Template/TemplateSubHeader.tsx
@@ -1,10 +1,14 @@
 import styled from '@emotion/styled';
-import { useContext } from 'react';
 
-import { MainContext } from '@/store';
+import { Questions } from '@/types/question.interface';
 
-export default function TemplateSubHeader() {
-  const { selectedRecordCard } = useContext(MainContext);
+type TemplateSubHeaderProps = {
+  onChange: (id: string, value: string | Questions[]) => void;
+};
+
+export default function TemplateSubHeader({
+  onChange,
+}: TemplateSubHeaderProps) {
   return (
     <TemplateContentContainer>
       <label htmlFor="template-title">템플릿 제목*</label>
@@ -12,11 +16,17 @@ export default function TemplateSubHeader() {
         type="text"
         name="template-title"
         id="template-title"
-        value={selectedRecordCard}
+        required
+        onChange={e => onChange('title', e.target.value)}
       />
       <br />
       <label htmlFor="template-title">설명</label>
-      <StyledInput type="text" name="template-title" id="template-title" />
+      <StyledInput
+        type="text"
+        name="template-title"
+        id="template-title"
+        onChange={e => onChange('description', e.target.value)}
+      />
     </TemplateContentContainer>
   );
 }

--- a/src/components/Template/index.tsx
+++ b/src/components/Template/index.tsx
@@ -1,6 +1,8 @@
 import { useContext } from 'react';
+import { mutate } from 'swr';
 
 import { createTemplate } from '@/apis/Template';
+import useRecord from '@/hooks/useRecord';
 import { MainContext } from '@/store';
 import { Questions } from '@/types/question.interface';
 
@@ -19,6 +21,8 @@ export default function Template() {
   const { loginToken, questionList, templateContent, setTemplateContent } =
     useContext(MainContext);
 
+  const { recordListData } = useRecord();
+
   const handleTemplateContent = (id: string, value: string | Questions[]) => {
     templateContent &&
       setTemplateContent({
@@ -32,7 +36,28 @@ export default function Template() {
       ...templateContent,
       questions: questionList,
     };
+
+    const newRecordListData = [
+      ...(recordListData || []),
+      {
+        id: recordListData
+          ? recordListData[recordListData?.length - 1].id + 1
+          : 1,
+        category: newTemplateContent.category,
+        title: newTemplateContent.title,
+        description: newTemplateContent.description,
+        createdAt: 'temporary',
+        updatedAt: 'temporary',
+      },
+    ];
+
     await createTemplate(loginToken.accessToken, newTemplateContent);
+
+    mutate(
+      ['record-templates', loginToken.accessToken],
+      newRecordListData,
+      false
+    );
   };
 
   return (

--- a/src/components/Template/index.tsx
+++ b/src/components/Template/index.tsx
@@ -1,5 +1,6 @@
 import { useContext } from 'react';
 
+import { createTemplate } from '@/apis/Template';
 import { MainContext } from '@/store';
 import { Questions } from '@/types/question.interface';
 
@@ -8,7 +9,8 @@ import TemplateFooter from './TemplateFooter';
 import TemplateTitle from './TemplateTitle';
 
 export default function Template() {
-  const { templateContent, setTemplateContent } = useContext(MainContext);
+  const { loginToken, questionList, templateContent, setTemplateContent } =
+    useContext(MainContext);
 
   const handleTemplateContent = (id: string, value: string | Questions[]) => {
     templateContent &&
@@ -18,15 +20,16 @@ export default function Template() {
       });
   };
 
-  // useEffect(() => {
-  //   console.log(templateContent);
-  // }, [templateContent]);
+  const handleClickedSaveButton = async () => {
+    handleTemplateContent('question', questionList);
+    await createTemplate(loginToken.accessToken, templateContent);
+  };
 
   return (
     <>
       <TemplateTitle />
       <TemplateContent onChange={handleTemplateContent} />
-      <TemplateFooter onChange={handleTemplateContent} />
+      <TemplateFooter handleClickedSaveButton={handleClickedSaveButton} />
     </>
   );
 }

--- a/src/components/Template/index.tsx
+++ b/src/components/Template/index.tsx
@@ -1,11 +1,32 @@
+import { useContext } from 'react';
+
+import { MainContext } from '@/store';
+import { Questions } from '@/types/question.interface';
+
 import TemplateContent from './TemplateContent';
+import TemplateFooter from './TemplateFooter';
 import TemplateTitle from './TemplateTitle';
 
 export default function Template() {
+  const { templateContent, setTemplateContent } = useContext(MainContext);
+
+  const handleTemplateContent = (id: string, value: string | Questions[]) => {
+    templateContent &&
+      setTemplateContent({
+        ...templateContent,
+        [id]: value,
+      });
+  };
+
+  // useEffect(() => {
+  //   console.log(templateContent);
+  // }, [templateContent]);
+
   return (
     <>
       <TemplateTitle />
-      <TemplateContent />
+      <TemplateContent onChange={handleTemplateContent} />
+      <TemplateFooter onChange={handleTemplateContent} />
     </>
   );
 }

--- a/src/components/Template/index.tsx
+++ b/src/components/Template/index.tsx
@@ -51,13 +51,9 @@ export default function Template() {
       },
     ];
 
-    await createTemplate(loginToken.accessToken, newTemplateContent);
+    await createTemplate(loginToken, newTemplateContent);
 
-    mutate(
-      ['record-templates', loginToken.accessToken],
-      newRecordListData,
-      false
-    );
+    mutate(['record-templates', loginToken], newRecordListData, false);
   };
 
   return (

--- a/src/components/Template/index.tsx
+++ b/src/components/Template/index.tsx
@@ -8,6 +8,13 @@ import TemplateContent from './TemplateContent';
 import TemplateFooter from './TemplateFooter';
 import TemplateTitle from './TemplateTitle';
 
+type NewTemplateContent = {
+  questions: Questions[];
+  category?: '' | 'INTERVIEW' | 'TREATMENT' | undefined;
+  title?: string | undefined;
+  description?: string | undefined;
+};
+
 export default function Template() {
   const { loginToken, questionList, templateContent, setTemplateContent } =
     useContext(MainContext);
@@ -21,8 +28,11 @@ export default function Template() {
   };
 
   const handleClickedSaveButton = async () => {
-    handleTemplateContent('question', questionList);
-    await createTemplate(loginToken.accessToken, templateContent);
+    const newTemplateContent: NewTemplateContent = {
+      ...templateContent,
+      questions: questionList,
+    };
+    await createTemplate(loginToken.accessToken, newTemplateContent);
   };
 
   return (

--- a/src/components/common/QuestionBox.tsx
+++ b/src/components/common/QuestionBox.tsx
@@ -9,6 +9,7 @@ type QuestionBoxProps = {
   description: string;
   tagName: string;
   margin?: string;
+  type: 'TEXT' | 'MEDIA' | 'SELECT' | 'PAIN_HSTRY' | 'CONDITION' | 'PAIN_INTV';
 };
 export default function QuestionBox({
   image,
@@ -16,6 +17,7 @@ export default function QuestionBox({
   description,
   tagName,
   margin,
+  type,
 }: QuestionBoxProps) {
   const { questionList, setQuestionList } = useContext(MainContext);
 
@@ -25,15 +27,22 @@ export default function QuestionBox({
         marginRight: margin,
       }}
       onClick={() => {
-        setQuestionList(prevQeusions => [
-          ...prevQeusions,
+        setQuestionList([
+          ...questionList,
           {
-            _id:
+            type,
+            order:
               questionList.length === 0
                 ? 1
-                : questionList[questionList.length - 1]._id + 1,
-            questionTitle: title,
+                : questionList[questionList.length - 1].order + 1,
+            required: false,
+            title,
             tagName,
+            description: '',
+            paragraph: false,
+            options: [],
+            allowMultiple: false,
+            addOtherOption: false,
           },
         ]);
       }}

--- a/src/components/common/SelectionBox.tsx
+++ b/src/components/common/SelectionBox.tsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
-import { useMemo } from 'react';
+import { useContext, useMemo } from 'react';
+
+import { MainContext } from '@/store';
 
 type SelectionBoxProps = {
   width?: number;
@@ -7,7 +9,6 @@ type SelectionBoxProps = {
   title: string;
   titleDescription: string;
   image: string;
-  onClick: React.Dispatch<React.SetStateAction<string>>;
 };
 
 export default function SelectionBox({
@@ -16,8 +17,9 @@ export default function SelectionBox({
   title,
   titleDescription,
   image,
-  onClick,
 }: SelectionBoxProps) {
+  const { templateContent, setTemplateContent, setSelectedTemplateTitle } =
+    useContext(MainContext);
   const selectionBoxContainerStyle = useMemo(
     () => ({
       width,
@@ -26,10 +28,21 @@ export default function SelectionBox({
     [width, height]
   );
 
+  const handleSelectionBox = () => {
+    setSelectedTemplateTitle(title);
+    setTemplateContent({
+      ...templateContent,
+      category: title === '문진 템플릿' ? 'INTERVIEW' : 'TREATMENT',
+      title: '',
+      description: '',
+      question: [],
+    });
+  };
+
   return (
     <SelectionBoxContainer
       style={{ ...selectionBoxContainerStyle }}
-      onClick={() => onClick(title)}
+      onClick={handleSelectionBox}
     >
       <TitleContainer>
         <div style={{ fontSize: '1rem', fontWeight: 'bold' }}>{title}</div>

--- a/src/components/common/SelectionBox.tsx
+++ b/src/components/common/SelectionBox.tsx
@@ -35,7 +35,7 @@ export default function SelectionBox({
       category: title === '문진 템플릿' ? 'INTERVIEW' : 'TREATMENT',
       title: '',
       description: '',
-      question: [],
+      questions: [],
     });
   };
 

--- a/src/hooks/useRecord.tsx
+++ b/src/hooks/useRecord.tsx
@@ -26,7 +26,9 @@ export default function useRecord(category?: string) {
   ).length;
 
   return {
-    recordListData: recordList?.filter(item => item.category === category),
+    recordListData: category
+      ? recordList?.filter(item => item.category === category)
+      : recordList,
     isLoading: !recordList && !error,
     error: error,
     mutate: mutate,

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -62,7 +62,7 @@ export const MainContext = React.createContext<ContextType>({
     category: '',
     title: '',
     description: '',
-    question: [],
+    questions: [],
   },
   setTemplateContent: () => {},
   setQuestions: () => {},

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -63,7 +63,7 @@ export const MainContext = React.createContext<ContextType>({
     category: '',
     title: '',
     description: '',
-    question: [],
+    questions: [],
   },
   setTemplateContent: () => {},
   setQuestions: () => {},

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -46,7 +46,6 @@ export const MainContext = React.createContext<ContextType>({
   recordModalOpen: false,
   mediaModalOpen: false,
   selectedTemplateTitle: '',
-
   questions: {
     type: '',
     order: 0,

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -7,7 +7,8 @@ import React, {
 } from 'react';
 import useSWR from 'swr';
 
-import { Question } from '@/types/question.interface';
+import { Questions } from '@/types/question.interface';
+import { Template } from '@/types/template.interface';
 import { tokenType } from '@/types/token.interface';
 import { categoryList, categoryListType } from '@/utils/constants/categoryList';
 import { mediaList, mediaListType } from '@/utils/constants/mediaList';
@@ -20,17 +21,21 @@ type ContextType = {
   selectedTemplateTitle: string;
 
   mediaList: mediaListType[];
-  questionList: Question[];
+  questionList: Questions[];
+  questions: Questions | undefined;
+  setQuestions: Dispatch<SetStateAction<Questions | undefined>>;
   storedCategoryList: categoryListType[];
 
   deleteMediaItem: (id: number) => void;
   setRecordModalState: Dispatch<SetStateAction<boolean>>;
   setMediaModalState: Dispatch<SetStateAction<boolean>>;
   setSelectedTemplateTitle: Dispatch<SetStateAction<string>>;
-  setQuestionList: Dispatch<SetStateAction<Question[]>>;
+  setQuestionList: Dispatch<SetStateAction<Questions[]>>;
   setStoredCategoryList: (storedCategoryList: categoryListType[]) => void;
   selectedRecordCard: string;
   setSelectedRecordCard: Dispatch<SetStateAction<string>>;
+  templateContent: Template | undefined;
+  setTemplateContent: Dispatch<SetStateAction<Template | undefined>>;
 };
 
 export const MainContext = React.createContext<ContextType>({
@@ -43,6 +48,26 @@ export const MainContext = React.createContext<ContextType>({
   mediaModalOpen: false,
   selectedTemplateTitle: '',
 
+  questions: {
+    type: '',
+    order: 0,
+    title: '',
+    tagName: '',
+    description: '',
+    required: false,
+    paragraph: false,
+    options: [],
+    allowMultiple: false,
+    addOtherOption: false,
+  },
+  templateContent: {
+    category: '',
+    title: '',
+    description: '',
+    question: [],
+  },
+  setTemplateContent: () => {},
+  setQuestions: () => {},
   deleteMediaItem: () => {},
   setRecordModalState: () => {},
   setMediaModalState: () => {},
@@ -73,7 +98,9 @@ export default function MainContextProvider(props: {
   const [recordModalState, setRecordModalState] = useState(false);
   const [mediaModalState, setMediaModalState] = useState(false);
   const [selectedTemplateTitle, setSelectedTemplateTitle] = useState('');
-  const [storedQuestionList, setStoredQuestionList] = useState<Question[]>([]);
+  const [questions, setQuestions] = useState<Questions>();
+  const [templateContent, setTemplateContent] = useState<Template>();
+  const [storedQuestionList, setStoredQuestionList] = useState<Questions[]>([]);
   const [selectedRecordCard, setSelectedRecordCard] = useState<string>('');
 
   const [storedMediaList, setStoredMediaList] =
@@ -116,6 +143,10 @@ export default function MainContextProvider(props: {
     storedCategoryList,
     selectedRecordCard,
     setSelectedRecordCard,
+    questions,
+    setQuestions,
+    templateContent,
+    setTemplateContent,
   };
 
   return (

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -7,8 +7,8 @@ import React, {
 } from 'react';
 import useSWR from 'swr';
 
-import { tokenType } from '@/types';
 import { Question } from '@/types/question.interface';
+import { tokenType } from '@/types/token.interface';
 import { categoryList, categoryListType } from '@/utils/constants/categoryList';
 import { mediaList, mediaListType } from '@/utils/constants/mediaList';
 import { recordList, recordListType } from '@/utils/constants/recordList';

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -7,7 +7,8 @@ import React, {
 } from 'react';
 import useSWR from 'swr';
 
-import { Question } from '@/types/question.interface';
+import { Questions } from '@/types/question.interface';
+import { Template } from '@/types/template.interface';
 import { tokenType } from '@/types/token.interface';
 import { categoryList, categoryListType } from '@/utils/constants/categoryList';
 import { mediaList, mediaListType } from '@/utils/constants/mediaList';
@@ -21,17 +22,21 @@ type ContextType = {
   selectedTemplateTitle: string;
   recordListData: recordListType[];
   mediaList: mediaListType[];
-  questionList: Question[];
+  questionList: Questions[];
+  questions: Questions | undefined;
+  setQuestions: Dispatch<SetStateAction<Questions | undefined>>;
   storedCategoryList: categoryListType[];
   deleteRecordItem: (id: number) => void;
   deleteMediaItem: (id: number) => void;
   setRecordModalState: Dispatch<SetStateAction<boolean>>;
   setMediaModalState: Dispatch<SetStateAction<boolean>>;
   setSelectedTemplateTitle: Dispatch<SetStateAction<string>>;
-  setQuestionList: Dispatch<SetStateAction<Question[]>>;
+  setQuestionList: Dispatch<SetStateAction<Questions[]>>;
   setStoredCategoryList: (storedCategoryList: categoryListType[]) => void;
   selectedRecordCard: string;
   setSelectedRecordCard: Dispatch<SetStateAction<string>>;
+  templateContent: Template | undefined;
+  setTemplateContent: Dispatch<SetStateAction<Template | undefined>>;
 };
 
 export const MainContext = React.createContext<ContextType>({
@@ -43,6 +48,26 @@ export const MainContext = React.createContext<ContextType>({
   recordModalOpen: false,
   mediaModalOpen: false,
   selectedTemplateTitle: '',
+  questions: {
+    type: '',
+    order: 0,
+    title: '',
+    tagName: '',
+    description: '',
+    required: false,
+    paragraph: false,
+    options: [],
+    allowMultiple: false,
+    addOtherOption: false,
+  },
+  templateContent: {
+    category: '',
+    title: '',
+    description: '',
+    question: [],
+  },
+  setTemplateContent: () => {},
+  setQuestions: () => {},
   deleteRecordItem: () => {},
   deleteMediaItem: () => {},
   setRecordModalState: () => {},
@@ -76,7 +101,9 @@ export default function MainContextProvider(props: {
   const [selectedTemplateTitle, setSelectedTemplateTitle] = useState('');
   const [storedRecordList, setStoredRecordList] =
     useState<recordListType[]>(recordList);
-  const [storedQuestionList, setStoredQuestionList] = useState<Question[]>([]);
+  const [questions, setQuestions] = useState<Questions>();
+  const [templateContent, setTemplateContent] = useState<Template>();
+  const [storedQuestionList, setStoredQuestionList] = useState<Questions[]>([]);
   const [selectedRecordCard, setSelectedRecordCard] = useState<string>('');
 
   const [storedMediaList, setStoredMediaList] =
@@ -125,6 +152,10 @@ export default function MainContextProvider(props: {
     storedCategoryList,
     selectedRecordCard,
     setSelectedRecordCard,
+    questions,
+    setQuestions,
+    templateContent,
+    setTemplateContent,
   };
 
   return (

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -6,7 +6,8 @@ import React, {
   useState,
 } from 'react';
 
-import { Question } from '@/types/question.interface';
+import { Questions } from '@/types/question.interface';
+import { Template } from '@/types/template.interface';
 import { categoryList, categoryListType } from '@/utils/constants/categoryList';
 import { mediaList, mediaListType } from '@/utils/constants/mediaList';
 
@@ -18,18 +19,22 @@ type ContextType = {
   selectedTemplateTitle: string;
 
   mediaList: mediaListType[];
-  questionList: Question[];
+  questionList: Questions[];
+  questions: Questions | undefined;
+  setQuestions: Dispatch<SetStateAction<Questions | undefined>>;
   storedCategoryList: categoryListType[];
 
   deleteMediaItem: (id: number) => void;
   setRecordModalState: Dispatch<SetStateAction<boolean>>;
   setMediaModalState: Dispatch<SetStateAction<boolean>>;
   setSelectedTemplateTitle: Dispatch<SetStateAction<string>>;
-  setQuestionList: Dispatch<SetStateAction<Question[]>>;
+  setQuestionList: Dispatch<SetStateAction<Questions[]>>;
   setStoredCategoryList: (storedCategoryList: categoryListType[]) => void;
   selectedRecordCard: string;
   setSelectedRecordCard: Dispatch<SetStateAction<string>>;
   setLoginToken: Dispatch<SetStateAction<string>>;
+  templateContent: Template | undefined;
+  setTemplateContent: Dispatch<SetStateAction<Template | undefined>>;
 };
 
 export const MainContext = React.createContext<ContextType>({
@@ -42,6 +47,26 @@ export const MainContext = React.createContext<ContextType>({
   mediaModalOpen: false,
   selectedTemplateTitle: '',
 
+  questions: {
+    type: '',
+    order: 0,
+    title: '',
+    tagName: '',
+    description: '',
+    required: false,
+    paragraph: false,
+    options: [],
+    allowMultiple: false,
+    addOtherOption: false,
+  },
+  templateContent: {
+    category: '',
+    title: '',
+    description: '',
+    question: [],
+  },
+  setTemplateContent: () => {},
+  setQuestions: () => {},
   deleteMediaItem: () => {},
   setRecordModalState: () => {},
   setMediaModalState: () => {},
@@ -68,7 +93,9 @@ export default function MainContextProvider(props: {
   const [recordModalState, setRecordModalState] = useState(false);
   const [mediaModalState, setMediaModalState] = useState(false);
   const [selectedTemplateTitle, setSelectedTemplateTitle] = useState('');
-  const [storedQuestionList, setStoredQuestionList] = useState<Question[]>([]);
+  const [questions, setQuestions] = useState<Questions>();
+  const [templateContent, setTemplateContent] = useState<Template>();
+  const [storedQuestionList, setStoredQuestionList] = useState<Questions[]>([]);
   const [selectedRecordCard, setSelectedRecordCard] = useState<string>('');
 
   const [storedMediaList, setStoredMediaList] =
@@ -112,6 +139,10 @@ export default function MainContextProvider(props: {
     selectedRecordCard,
     setSelectedRecordCard,
     setLoginToken,
+    questions,
+    setQuestions,
+    templateContent,
+    setTemplateContent,
   };
 
   return (

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -47,7 +47,6 @@ export const MainContext = React.createContext<ContextType>({
   recordModalOpen: false,
   mediaModalOpen: false,
   selectedTemplateTitle: '',
-
   questions: {
     type: '',
     order: 0,

--- a/src/types/question.interface.ts
+++ b/src/types/question.interface.ts
@@ -1,7 +1,21 @@
-export interface Question {
-  _id: number;
-  questionTitle: string;
+export interface Questions {
+  type:
+    | ''
+    | 'TEXT'
+    | 'MEDIA'
+    | 'SELECT'
+    | 'PAIN_HSTRY'
+    | 'CONDITION'
+    | 'PAIN_INTV';
+  order: number;
+  title: string;
   tagName: string;
+  description?: string;
+  required: boolean;
+  paragraph?: boolean;
+  options?: string[];
+  allowMultiple?: boolean;
+  addOtherOption?: boolean;
 }
 
 export interface AddedFile {

--- a/src/types/template.interface.ts
+++ b/src/types/template.interface.ts
@@ -1,21 +1,8 @@
+import { Questions } from './question.interface';
+
 export interface Template {
-  category: 'INTERVIEW' | 'TREATMENT';
+  category: '' | 'INTERVIEW' | 'TREATMENT';
   title: string;
   description?: string;
-  question: {
-    type:
-      | 'TEXT'
-      | 'MEDIA'
-      | 'SELECT'
-      | 'PAIN_HSTRY'
-      | 'CONDITION'
-      | 'PAIN_INTV';
-    order: number;
-    description?: string;
-    required: boolean;
-    paragraph?: boolean;
-    options?: string[];
-    allowMultiple?: boolean;
-    addOtherOption?: boolean;
-  };
+  question: Questions[];
 }

--- a/src/types/template.interface.ts
+++ b/src/types/template.interface.ts
@@ -10,4 +10,5 @@ export interface Template {
 export interface CreateTemplateResponse {
   id: number;
   message: string;
+  question: Questions[];
 }

--- a/src/types/template.interface.ts
+++ b/src/types/template.interface.ts
@@ -4,5 +4,10 @@ export interface Template {
   category: '' | 'INTERVIEW' | 'TREATMENT';
   title: string;
   description?: string;
-  question: Questions[];
+  questions: Questions[];
+}
+
+export interface CreateTemplateResponse {
+  id: number;
+  message: string;
 }

--- a/src/types/template.interface.ts
+++ b/src/types/template.interface.ts
@@ -1,0 +1,21 @@
+export interface Template {
+  category: 'INTERVIEW' | 'TREATMENT';
+  title: string;
+  description?: string;
+  question: {
+    type:
+      | 'TEXT'
+      | 'MEDIA'
+      | 'SELECT'
+      | 'PAIN_HSTRY'
+      | 'CONDITION'
+      | 'PAIN_INTV';
+    order: number;
+    description?: string;
+    required: boolean;
+    paragraph?: boolean;
+    options?: string[];
+    allowMultiple?: boolean;
+    addOtherOption?: boolean;
+  };
+}


### PR DESCRIPTION
## 💡 이슈 번호

close #54 

## 📖 작업 내용
- [X] request body 형식에 맞춰 데이터 key, value 설정
- [X] 기록 템플릿 생성 api 연동 (처치)

## ✅ PR 포인트

- request body 형식에 맞춰 데이터를 설정하는 작업을 진행했어요.
- 기록 템플릿 생성 api를 연동했어요.
- mutate를 적용해 생성이 완료되면 곧바로 화면에서 확인할 수 있도록 구현했어요.
- 타입 및 자잘한 기능은 이후 이슈에서 해결할 예정이에요.

## 📸 스크린샷
![image](https://github.com/pie-sfac/5-17-smokedDuck/assets/33304871/45af51f6-8df9-47ff-b2e9-0a480f5717bf)
![image](https://github.com/pie-sfac/5-17-smokedDuck/assets/33304871/e28fae26-41e5-4913-a4c4-0c465f96d372)
