### PR TITLE
feat: 로그인 토큰 만료 확인 및 갱신

### DIFF
--- a/src/apis/Category.ts
+++ b/src/apis/Category.ts
@@ -5,67 +5,46 @@ import {
   CategoryRequestDTO,
   CategoryResponseDTO,
 } from '@/types/category.interface';
-import { header } from '@/utils/validations/linkUtils';
 
 export const BASE_URL: string = import.meta.env.VITE_BASE_URL as string;
 export const LINK_URL = 'archive-link-categories';
 
 export async function deleteCategory(
-  categoryId: number,
-  tokenData: string
+  categoryId: number
 ): Promise<CategoryResponseDTO> {
-  const headers = {
-    Authorization: `Bearer ${tokenData}`,
-  };
   const response: AxiosResponse<CategoryResponseDTO> = await axios.delete(
-    `${BASE_URL}/${LINK_URL}/${categoryId}`,
-    { headers }
+    `${LINK_URL}/${categoryId}`
   );
   return response.data;
 }
 
 export async function updateCategory(
   categoryId: number,
-  categoryData: CategoryRequestDTO,
-  tokenData: string
+  categoryData: CategoryRequestDTO
 ): Promise<CategoryListResponseDTO> {
-  const headers = {
-    Authorization: `Bearer ${tokenData}`,
-    'Content-Type': 'application/json',
-  };
-  const requestUrl = `${BASE_URL}/${LINK_URL}/${categoryId}`;
+  const requestUrl = `/${LINK_URL}/${categoryId}`;
   const response: AxiosResponse<CategoryListResponseDTO> = await axios.put(
     requestUrl,
-    categoryData,
-    { headers }
+    categoryData
   );
   return response.data;
 }
 
-export async function getCategoryList(
-  token: string
-): Promise<CategoryListResponseDTO> {
-  const requestUrl = `${BASE_URL}/${LINK_URL}`;
+export async function getCategoryList(): Promise<CategoryListResponseDTO> {
+  const requestUrl = `/${LINK_URL}`;
   const response: AxiosResponse<CategoryListResponseDTO> = await axios.get(
-    requestUrl,
-    { headers: header(token) }
+    requestUrl
   );
 
   return response.data;
 }
 
 export async function createCategory(
-  tokenData: string,
   categoryData: CategoryRequestDTO
 ): Promise<CategoryResponseDTO> {
-  const headers = {
-    Authorization: `Bearer ${tokenData}`,
-    'Content-Type': 'application/json',
-  };
   const response: AxiosResponse<CategoryResponseDTO> = await axios.post(
-    `${BASE_URL}/${LINK_URL}`,
-    categoryData,
-    { headers }
+    `/${LINK_URL}`,
+    categoryData
   );
   return response.data;
 }

--- a/src/apis/Login.ts
+++ b/src/apis/Login.ts
@@ -1,0 +1,28 @@
+import axios from 'axios';
+
+import { tokenType } from '@/types/token.interface';
+
+// const refreshAxios = axios.create({
+//   baseURL: 'http://223.130.161.221/api/v1',
+//   headers: { Authorization: `Bearer ${localStorage.getItem('refreshToken')}` },
+// });
+
+const JWT_EXPIRRY_TIME = 1000 * 60 * 15;
+
+export function onSlientRefresh() {
+  const headers = {
+    Authorization: `Bearer ${localStorage.getItem('refreshToken')}`,
+    'Content-Type': 'application/json',
+  };
+  axios.post('/tokens', '', {
+    headers,
+  });
+}
+
+export function onLoginSuccess(res: { data: tokenType }) {
+  const { accessToken } = res.data;
+
+  axios.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
+
+  setTimeout(onSlientRefresh, JWT_EXPIRRY_TIME - 60000);
+}

--- a/src/apis/Login.ts
+++ b/src/apis/Login.ts
@@ -2,27 +2,52 @@ import axios from 'axios';
 
 import { tokenType } from '@/types/token.interface';
 
-// const refreshAxios = axios.create({
-//   baseURL: 'http://223.130.161.221/api/v1',
-//   headers: { Authorization: `Bearer ${localStorage.getItem('refreshToken')}` },
-// });
+const refreshAxios = axios.create({
+  baseURL: 'http://223.130.161.221/api/v1',
+  headers: {
+    common: {
+      Authorization: `Bearer ${localStorage.getItem('refreshToken')}`,
+    },
+  },
+  withCredentials: true,
+});
 
 const JWT_EXPIRRY_TIME = 1000 * 60 * 15;
 
-export function onSlientRefresh() {
+export async function requestLogin(username: string, password: string) {
+  const basicToken = btoa(`${username}:${password}`);
   const headers = {
-    Authorization: `Bearer ${localStorage.getItem('refreshToken')}`,
-    'Content-Type': 'application/json',
+    Authorization: `Basic ${basicToken}`,
   };
-  axios.post('/tokens', '', {
-    headers,
+
+  await axios
+    .post<tokenType>(`/admins/login`, '', {
+      headers,
+      withCredentials: true,
+    })
+    .then(res => {
+      onLoginSuccess(res);
+      window.localStorage.setItem('refreshToken', res.data.refreshToken);
+    })
+    .catch(error => {
+      alert('아이디 또는 비밀번호가 틀렸습니다.');
+      console.error(error);
+    });
+}
+
+export function onSlientRefresh() {
+  refreshAxios.post<tokenType>('/tokens').then(res => {
+    onLoginSuccess(res);
+    window.localStorage.setItem('refreshToken', res.data.refreshToken);
   });
 }
 
 export function onLoginSuccess(res: { data: tokenType }) {
-  const { accessToken } = res.data;
+  const { accessToken, refreshToken } = res.data;
 
   axios.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
-
+  refreshAxios.defaults.headers.common[
+    'Authorization'
+  ] = `Bearer ${refreshToken}`;
   setTimeout(onSlientRefresh, JWT_EXPIRRY_TIME - 60000);
 }

--- a/src/apis/Media.ts
+++ b/src/apis/Media.ts
@@ -8,67 +8,56 @@ import {
   UpdateLinkProps,
   UpdateLinkResponse,
 } from '@/types/media.interface';
-import { header } from '@/utils/validations/linkUtils';
 
-export const BASE_URL: string = import.meta.env.VITE_BASE_URL as string;
 export const LINK_URL = 'archive-links';
 
 export async function updateLink(
   linkId: number,
-  requestData: UpdateLinkProps,
-  token: string
+  requestData: UpdateLinkProps
 ): Promise<UpdateLinkResponse> {
-  const requestUrl = `${BASE_URL}/${LINK_URL}/${linkId}`;
+  const requestUrl = `${LINK_URL}/${linkId}`;
   const response: AxiosResponse<UpdateLinkResponse> = await axios.put(
     requestUrl,
-    requestData,
-    { headers: header(token) }
+    requestData
   );
   return response.data;
 }
 
 export async function createLink(
-  requestData: CreateLinkProps,
-  token: string
+  requestData: CreateLinkProps
 ): Promise<CreateLinkResponse> {
-  const requestUrl = `${BASE_URL}/${LINK_URL}`;
+  const requestUrl = `/${LINK_URL}`;
   const response: AxiosResponse<CreateLinkResponse> = await axios.post(
     requestUrl,
-    requestData,
-    { headers: header(token) }
+    requestData
   );
   return response.data;
 }
 
-export async function getLinkList(token: string): Promise<GetLinkListResponse> {
-  const requestUrl = `${BASE_URL}/${LINK_URL}`;
+export async function getLinkList(): Promise<GetLinkListResponse> {
+  const requestUrl = `/${LINK_URL}`;
   const response: AxiosResponse<GetLinkListResponse> = await axios.get(
-    requestUrl,
-    { headers: header(token) }
+    requestUrl
   );
   return response.data;
 }
 
 export async function getLinkDetails(
-  linkId: number,
-  token: string
+  linkId: number
 ): Promise<GetLinkDetailResponse> {
-  const requestUrl = `${BASE_URL}/${LINK_URL}/${linkId}`;
+  const requestUrl = `/${LINK_URL}/${linkId}`;
   const response: AxiosResponse<GetLinkDetailResponse> = await axios.get(
-    requestUrl,
-    { headers: header(token) }
+    requestUrl
   );
   return response.data;
 }
 
 export async function deleteLink(
-  linkId: number,
-  token: string
+  linkId: number
 ): Promise<GetLinkDetailResponse> {
-  const requestUrl = `${BASE_URL}/${LINK_URL}/${linkId}`;
+  const requestUrl = `/${LINK_URL}/${linkId}`;
   const response: AxiosResponse<GetLinkDetailResponse> = await axios.delete(
-    requestUrl,
-    { headers: header(token) }
+    requestUrl
   );
   return response.data;
 }

--- a/src/apis/Youtube.ts
+++ b/src/apis/Youtube.ts
@@ -9,11 +9,13 @@ export interface YoutubeVideoAPIResponse {
 export async function fetchYoutubeVideo(
   videoId: string
 ): Promise<YoutubeVideoAPIResponse> {
-  const requestUrl = `https://www.googleapis.com/youtube/v3/videos?part=snippet&id=${videoId}&key=${
-    import.meta.env.VITE_APP_GA_API_KEY
-  }`;
-  const responseData: AxiosResponse<YoutubeVideoAPIResponse> = await axios.get(
-    requestUrl
-  );
+  const youTubeAxios = axios.create({
+    baseURL: `https://www.googleapis.com/youtube/v3/videos?part=snippet&id=${videoId}&key=${
+      import.meta.env.VITE_APP_GA_API_KEY
+    }`,
+  });
+  delete youTubeAxios.defaults.headers.common['Authorization'];
+  const responseData: AxiosResponse<YoutubeVideoAPIResponse> =
+    await youTubeAxios.get('');
   return responseData.data;
 }

--- a/src/apis/record.ts
+++ b/src/apis/record.ts
@@ -5,25 +5,11 @@ import { recordListResponseType } from '@/types/recordList.interface';
 
 const baseUrl = import.meta.env.VITE_BASE_URL as string;
 
-export async function recordListFetcher([url, tokenData]: string[]) {
-  const headers = {
-    Authorization: `Bearer ${tokenData}`,
-    'Content-Type': 'application/json',
-  };
-  const res = await axios.get<recordListResponseType>(`${baseUrl}/${url}`, {
-    headers,
-  });
+export async function recordListFetcher(url: string) {
+  const res = await axios.get<recordListResponseType>(`${baseUrl}/${url}`);
   return res.data.templates;
 }
 
-export function recordDetailFetcher([url, tokenData]: string[]) {
-  const headers = {
-    Authorization: `Bearer ${tokenData}`,
-    'Content-Type': 'application/json',
-  };
-  return axios
-    .get<recordDetailType>(`${baseUrl}/${url}`, {
-      headers,
-    })
-    .then(res => res.data);
+export function recordDetailFetcher(url: string) {
+  return axios.get<recordDetailType>(`${url}`).then(res => res.data);
 }

--- a/src/components/Category/index.tsx
+++ b/src/components/Category/index.tsx
@@ -19,8 +19,6 @@ export default function Category() {
   const [isAddingCategory, setIsAddingCategory] = useState(false);
   const newCategoryInputRef = useRef<HTMLInputElement>(null);
   const navigate = useNavigate();
-
-  const { loginToken } = useContext(MainContext);
   const { categoryListData, mutate } = useCategory();
 
   const handleAddCategory = useCallback(async () => {
@@ -31,7 +29,6 @@ export default function Category() {
       };
 
       const newCategory: CategoryResponseDTO | undefined = await createCategory(
-        loginToken,
         newCategoryList
       );
 
@@ -53,7 +50,7 @@ export default function Category() {
     } catch (error) {
       console.error('카테고리 추가 중 오류 발생:', error);
     }
-  }, [categoryListData, loginToken, mutate]);
+  }, [categoryListData, mutate]);
 
   const handleModifyCategory = useCallback(
     async (categoryId: number, updateText: string) => {
@@ -63,7 +60,7 @@ export default function Category() {
           description: '',
         };
         const updatedCategory: CategoryListResponseDTO | undefined =
-          await updateCategory(categoryId, updatedCategoryData, loginToken);
+          await updateCategory(categoryId, updatedCategoryData);
 
         if (categoryListData && updatedCategory) {
           const updatedCategoryListData = {
@@ -81,7 +78,7 @@ export default function Category() {
         console.error('카테고리 수정 중 오류 발생:', error);
       }
     },
-    [categoryListData, loginToken, mutate]
+    [categoryListData, mutate]
   );
 
   const handleCheckboxChange = useCallback(

--- a/src/components/Link/LinkForm.tsx
+++ b/src/components/Link/LinkForm.tsx
@@ -40,6 +40,9 @@ export default function LinkForm({ onSubmit, linkId }: LinkFormProps) {
   const [isFormComplete, setIsFormComplete] = useState(false);
   const { youtubeVideo, handler } = useYoutubeVideo();
 
+  const [isTitleChanged, setIsTitleChanged] = useState(false);
+  const [isDescriptionChanged, setIsDescriptionChanged] = useState(false);
+
   const isRequiredFieldsEmpty = !category || !linkUrl || !title;
 
   const handleLinkChange = useCallback(
@@ -61,7 +64,7 @@ export default function LinkForm({ onSubmit, linkId }: LinkFormProps) {
     }
 
     setIsFormComplete(true);
-  }, [media, categories]);
+  }, [media, categories, linkUrl]);
 
   useEffect(() => {
     const updateFormCompletion = () => {
@@ -75,16 +78,22 @@ export default function LinkForm({ onSubmit, linkId }: LinkFormProps) {
     updateFormCompletion();
 
     setDescription(
-      description ||
-        (youtubeVideo && youtubeVideo.description) ||
-        media?.description ||
-        ''
+      isDescriptionChanged
+        ? description
+        : youtubeVideo?.description || media?.description || ''
     );
 
     setTitle(
-      title || (youtubeVideo && youtubeVideo.title) || media?.title || ''
+      isTitleChanged ? title : youtubeVideo?.title || media?.title || ''
     );
-  }, [youtubeVideo, media]);
+  }, [
+    youtubeVideo,
+    media,
+    isDescriptionChanged,
+    isTitleChanged,
+    title,
+    description,
+  ]);
 
   const handleSubmit = useCallback(() => {
     if (isRequiredFieldsEmpty) {
@@ -103,16 +112,20 @@ export default function LinkForm({ onSubmit, linkId }: LinkFormProps) {
         (youtubeVideo && youtubeVideo.thumbnailUrl) ||
         getLinkUrlInfo(media?.url || '').thumbnailUrl ||
         '',
-      title: title || (youtubeVideo && youtubeVideo.title) || '',
+      title: isTitleChanged
+        ? title
+        : (youtubeVideo && youtubeVideo.title) || '',
     });
   }, [
+    isRequiredFieldsEmpty,
     category,
     linkUrl,
+    media?.url,
     title,
     description,
     onSubmit,
     youtubeVideo,
-    isRequiredFieldsEmpty,
+    isTitleChanged,
   ]);
 
   return (
@@ -159,9 +172,10 @@ export default function LinkForm({ onSubmit, linkId }: LinkFormProps) {
 
         <Input
           type="text"
-          value={title || youtubeVideo?.title}
+          value={isTitleChanged ? title : youtubeVideo?.title || ''}
           onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
             setTitle(event.target.value);
+            setIsTitleChanged(true);
           }}
           placeholder="링크 제목을 입력해 주세요."
           width="800px"
@@ -172,10 +186,13 @@ export default function LinkForm({ onSubmit, linkId }: LinkFormProps) {
 
       <DescriptionBox>
         <Textarea
-          value={description || youtubeVideo?.description}
+          value={
+            isDescriptionChanged ? description : youtubeVideo?.description || ''
+          }
           onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
             const { value } = event.target;
             setDescription(value.slice(0, 500));
+            setIsDescriptionChanged(true);
           }}
           placeholder="링크를 식별하기 위한 간단한 메모를 작성해 주세요. (500자 이내)"
           resize="none"

--- a/src/components/Link/LinkForm.tsx
+++ b/src/components/Link/LinkForm.tsx
@@ -29,7 +29,7 @@ export default function LinkForm({ onSubmit, linkId }: LinkFormProps) {
   const { data: media } = useSWR(
     linkId ? [`${LINK_URL}${linkId}`, loginToken || ''] : null,
     linkId && loginToken
-      ? ([_, accessToken]) => getLinkDetails(linkId, accessToken)
+      ? ([accessToken]) => getLinkDetails(linkId, accessToken)
       : null
   );
 
@@ -60,7 +60,7 @@ export default function LinkForm({ onSubmit, linkId }: LinkFormProps) {
       setLinkUrl(getLinkUrlInfo((media && media.url) || '').linkUrl);
       if (categories) setCategory(media && media.category?.id);
     }
-  }, [media]);
+  }, [categories, media]);
 
   useEffect(() => {
     const updateFormCompletion = () => {
@@ -79,7 +79,7 @@ export default function LinkForm({ onSubmit, linkId }: LinkFormProps) {
         (media && media.description) ||
         ''
     );
-  }, [youtubeVideo]);
+  }, [media, youtubeVideo]);
 
   const handleSubmit = useCallback(() => {
     if (isRequiredFieldsEmpty) {
@@ -101,13 +101,14 @@ export default function LinkForm({ onSubmit, linkId }: LinkFormProps) {
       title: title || (youtubeVideo && youtubeVideo.title) || '',
     });
   }, [
+    isRequiredFieldsEmpty,
     category,
     linkUrl,
+    media?.url,
     title,
     description,
     onSubmit,
     youtubeVideo,
-    isRequiredFieldsEmpty,
   ]);
 
   return (

--- a/src/components/Link/LinkForm.tsx
+++ b/src/components/Link/LinkForm.tsx
@@ -8,13 +8,12 @@ import {
   Textarea,
 } from '@chakra-ui/react';
 import styled from '@emotion/styled';
-import React, { useCallback, useContext, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import useSWR from 'swr';
 
 import { getLinkDetails, LINK_URL } from '@/apis/Media';
 import useCategory from '@/hooks/useCategory';
 import { useYoutubeVideo } from '@/hooks/UseYoutubeVideo';
-import { MainContext } from '@/store/index';
 import { CategoryResponseDTO } from '@/types/category.interface';
 import { FormData } from '@/types/media.interface';
 import { getLinkUrlInfo } from '@/utils/validations/linkUtils';
@@ -25,12 +24,9 @@ interface LinkFormProps {
 }
 
 export default function LinkForm({ onSubmit, linkId }: LinkFormProps) {
-  const { loginToken } = useContext(MainContext);
   const { data: media } = useSWR(
-    linkId ? [`${LINK_URL}${linkId}`, loginToken || ''] : null,
-    linkId && loginToken
-      ? ([_, accessToken]) => getLinkDetails(linkId, accessToken)
-      : null
+    linkId ? `${LINK_URL}${linkId}` : null,
+    linkId ? () => getLinkDetails(linkId) : null
   );
 
   const [linkUrl, setLinkUrl] = useState('');

--- a/src/components/Link/LinkForm.tsx
+++ b/src/components/Link/LinkForm.tsx
@@ -37,6 +37,7 @@ export default function LinkForm({ onSubmit, linkId }: LinkFormProps) {
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [category, setCategory] = useState<number | undefined>(undefined);
+
   const [isFormComplete, setIsFormComplete] = useState(false);
   const { youtubeVideo, handler } = useYoutubeVideo();
 

--- a/src/components/Link/LinkForm.tsx
+++ b/src/components/Link/LinkForm.tsx
@@ -29,7 +29,7 @@ export default function LinkForm({ onSubmit, linkId }: LinkFormProps) {
   const { data: media } = useSWR(
     linkId ? [`${LINK_URL}${linkId}`, loginToken || ''] : null,
     linkId && loginToken
-      ? ([accessToken]) => getLinkDetails(linkId, accessToken)
+      ? ([_, accessToken]) => getLinkDetails(linkId, accessToken)
       : null
   );
 

--- a/src/components/Link/LinkView.tsx
+++ b/src/components/Link/LinkView.tsx
@@ -1,11 +1,9 @@
 import { Box, Heading, Image, Text } from '@chakra-ui/react';
 import styled from '@emotion/styled';
-import { useContext } from 'react';
 import useSWR from 'swr';
 
 import { getLinkDetails, LINK_URL } from '@/apis/Media';
 import Logo from '@/assets/Logo.svg';
-import { MainContext } from '@/store';
 import { GetLinkDetailResponse } from '@/types/media.interface';
 import { getLinkUrlInfo } from '@/utils/validations/linkUtils';
 
@@ -14,14 +12,9 @@ interface LinkViewProps {
 }
 
 function LinkView({ linkId }: LinkViewProps) {
-  const { loginToken } = useContext(MainContext);
-
-  const { data: media } = useSWR<
-    GetLinkDetailResponse,
-    never,
-    [string, string]
-  >([`${LINK_URL}${linkId}`, loginToken || ''], ([_, accessToken]) =>
-    getLinkDetails(linkId, accessToken)
+  const { data: media } = useSWR<GetLinkDetailResponse, never>(
+    `${LINK_URL}${linkId}`,
+    () => getLinkDetails(linkId)
   );
 
   const [mediaUrl] = (media?.url || '').split(';');

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -14,7 +14,6 @@ import {
   GetLinkDetailResponse,
   GetLinkListResponse,
 } from '@/types/media.interface';
-
 export interface LinkComponentProps {
   mode: 'CREATE' | 'UPDATE';
   linkId?: number;

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -43,17 +43,10 @@ export default function LinkComponent({ mode, linkId }: LinkComponentProps) {
       mutate(
         [LINK_URL, accessToken],
         (data: GetLinkListResponse | undefined) => {
-          const updatedArchiveLinks = [...(data?.archiveLinks || [])];
+          const updatedArchiveLinks = (data?.archiveLinks || []).map(link =>
+            link.id === fetchLinkDetails.id ? fetchLinkDetails : link
+          );
 
-          if (linkId) {
-            let updatedTargetLinkIndex = 0;
-            for (let i = 0; i < updatedArchiveLinks.length; i++) {
-              if (updatedArchiveLinks[i].id == fetchLinkDetails.id) {
-                updatedTargetLinkIndex = i;
-              }
-            }
-            updatedArchiveLinks[updatedTargetLinkIndex] = fetchLinkDetails;
-          }
           return {
             archiveLinks: updatedArchiveLinks,
             message: data?.message || '',

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -14,7 +14,6 @@ interface StyledPasswordIconProps {
 
 export default function LoginForm() {
   axios.defaults.baseURL = 'http://223.130.161.221/api/v1';
-
   const [username, setUsername] = useState<string>('');
   const [password, setPassword] = useState<string>('');
   const [showPassword, setShowPassword] = useState<boolean>(false);

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -1,21 +1,20 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import axios from 'axios';
-import { useCallback, useContext, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { requestLogin } from '@/apis/Login';
 import Logo from '@/assets/Logo.svg';
 import VisibilityOn from '@/assets/VisibilityOn.svg';
-import { MainContext } from '@/store';
-import { tokenType } from '@/types/token.interface';
+
 interface StyledPasswordIconProps {
   password: string;
 }
 
 export default function LoginForm() {
   axios.defaults.baseURL = 'http://223.130.161.221/api/v1';
-  axios.defaults.withCredentials = true;
-  const { setLoginToken } = useContext(MainContext);
+
   const [username, setUsername] = useState<string>('');
   const [password, setPassword] = useState<string>('');
   const [showPassword, setShowPassword] = useState<boolean>(false);
@@ -26,31 +25,14 @@ export default function LoginForm() {
     username.length === 0 || password.length === 0;
 
   const handleSubmit = useCallback(
-    async (event: React.FormEvent<HTMLFormElement>) => {
+    (event: React.FormEvent<HTMLFormElement>) => {
       event.preventDefault();
 
-      try {
-        const basicToken = btoa(`${username}:${password}`);
-        const headers = {
-          Authorization: `Basic ${basicToken}`,
-        };
-        const response = await axios.post<tokenType>(`/admins/login`, '', {
-          headers,
-        });
-        // axios.defaults.headers.common[
-        //   'Authorization'
-        // ] = `Bearer ${response.data.accessToken}`;
-        setLoginToken(response.data.accessToken);
-        window.localStorage.setItem('token', response.data.accessToken);
-        window.localStorage.setItem('refreshToken', response.data.refreshToken);
-
-        navigate('record');
-      } catch (error) {
-        alert('아이디 또는 비밀번호가 틀렸습니다.');
-        console.error('error');
-      }
+      requestLogin(username, password).then(() => {
+        navigate('/record');
+      });
     },
-    [username, password, navigate, setLoginToken]
+    [username, password, navigate]
   );
 
   return (

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -13,7 +13,8 @@ interface StyledPasswordIconProps {
 }
 
 export default function LoginForm() {
-  const baseUrl = import.meta.env.VITE_BASE_URL as string;
+  axios.defaults.baseURL = 'http://223.130.161.221/api/v1';
+  axios.defaults.withCredentials = true;
   const { setLoginToken } = useContext(MainContext);
   const [username, setUsername] = useState<string>('');
   const [password, setPassword] = useState<string>('');
@@ -32,13 +33,13 @@ export default function LoginForm() {
         const basicToken = btoa(`${username}:${password}`);
         const headers = {
           Authorization: `Basic ${basicToken}`,
-          'Content-Type': 'application/json',
         };
-        const response = await axios.post<tokenType>(
-          `${baseUrl}/admins/login`,
-          '',
-          { headers }
-        );
+        const response = await axios.post<tokenType>(`/admins/login`, '', {
+          headers,
+        });
+        // axios.defaults.headers.common[
+        //   'Authorization'
+        // ] = `Bearer ${response.data.accessToken}`;
         setLoginToken(response.data.accessToken);
         window.localStorage.setItem('token', response.data.accessToken);
         window.localStorage.setItem('refreshToken', response.data.refreshToken);
@@ -49,7 +50,7 @@ export default function LoginForm() {
         console.error('error');
       }
     },
-    [username, password, navigate, baseUrl, setLoginToken]
+    [username, password, navigate, setLoginToken]
   );
 
   return (

--- a/src/components/common/DeleteModal/index.tsx
+++ b/src/components/common/DeleteModal/index.tsx
@@ -21,7 +21,6 @@ type DeleteModalPropsType = {
   title: string;
   text: string;
 };
-const baseUrl = import.meta.env.VITE_BASE_URL as string;
 
 export default function DeleteModalContainer({
   id,
@@ -31,34 +30,26 @@ export default function DeleteModalContainer({
 }: DeleteModalPropsType) {
   const { pathname } = useLocation();
 
-  const { loginToken, selectedIds, setSelectedIds } = useContext(MainContext);
+  const { selectedIds, setSelectedIds } = useContext(MainContext);
   const { recordListData, mutate } = useRecord();
   const { categoryListData, mutate: mutateCategory } = useCategory();
 
   const handleDeleteClick = async () => {
-    const headers = {
-      Authorization: `Bearer ${loginToken}`,
-      'Content-Type': 'application/json',
-    };
-
     if (pathname === '/record' && recordListData) {
       const newRecordList: recordListType = recordListData.filter(
         (item: { id: number }) => item.id !== id
       );
 
-      await mutate(
-        axios.delete(`${baseUrl}/record-templates/${Number(id)}`, { headers }),
-        {
-          optimisticData: newRecordList,
-          populateCache: false,
-        }
-      );
+      await mutate(axios.delete(`record-templates/${Number(id)}`), {
+        optimisticData: newRecordList,
+        populateCache: false,
+      });
     }
 
     if (pathname === '/media') {
-      deleteLink(Number(id), loginToken);
+      deleteLink(Number(id));
       globalMutate(
-        [LINK_URL, loginToken],
+        LINK_URL,
         (data: GetLinkListResponse | undefined) => {
           const updatedArchiveLinks = [...(data?.archiveLinks || [])];
 
@@ -74,7 +65,7 @@ export default function DeleteModalContainer({
     }
 
     if (pathname === '/category') {
-      selectedIds.map((id: number) => deleteCategory(id, loginToken));
+      selectedIds.map((id: number) => deleteCategory(id));
       const updatedCategoryList = categoryListData?.categories.slice() || [];
       selectedIds.forEach(id => {
         const index = updatedCategoryList.findIndex(item => item.id === id);

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,21 +1,25 @@
 import { Avatar } from '@chakra-ui/react';
 import styled from '@emotion/styled';
-import { useCallback, useContext, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { onSlientRefresh } from '@/apis/Login';
 import Logo from '@/assets/Logo.svg';
-import { MainContext } from '@/store';
 import { category, userName } from '@/utils/constants/header';
 import { categoryType } from '@/utils/constants/header';
 
 export default function Header() {
   const navigate = useNavigate();
-  const { loginToken } = useContext(MainContext);
   const { pathname } = useLocation();
   const [clickedIdNum, setClickedIdNum] = useState<number>(2);
 
-  onSlientRefresh();
+  useEffect(() => {
+    if (!localStorage.getItem('refreshToken')) {
+      navigate('/');
+    } else {
+      onSlientRefresh();
+    }
+  }, [navigate]);
 
   const handlePageMove = (item: categoryType) => {
     if (item.id === 2 || item.id === 3) {
@@ -31,10 +35,6 @@ export default function Header() {
 
   if (pathname === '/') {
     return null;
-  }
-
-  if (loginToken === '') {
-    navigate('/');
   }
 
   return (

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,21 +1,25 @@
 import { Avatar } from '@chakra-ui/react';
 import styled from '@emotion/styled';
-import { useCallback, useContext, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { onSlientRefresh } from '@/apis/Login';
 import Logo from '@/assets/Logo.svg';
-import { MainContext } from '@/store';
 import { category, userName } from '@/utils/constants/header';
 import { categoryType } from '@/utils/constants/header';
 
 export default function Header() {
   const navigate = useNavigate();
-  const { loginToken } = useContext(MainContext);
   const { pathname } = useLocation();
   const [clickedIdNum, setClickedIdNum] = useState<number>(2);
 
-  onSlientRefresh();
+  useEffect(() => {
+    if (!localStorage.getItem('refreshToken')) {
+      navigate('/');
+    } else {
+      onSlientRefresh();
+    }
+  }, [navigate]);
 
   const handlePageMove = (item: categoryType) => {
     if (item.id === 2 || item.id === 3) {
@@ -32,10 +36,6 @@ export default function Header() {
 
   if (pathname === '/') {
     return null;
-  }
-
-  if (loginToken === '') {
-    navigate('/');
   }
 
   return (

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import { useCallback, useContext, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
+import { onSlientRefresh } from '@/apis/Login';
 import Logo from '@/assets/Logo.svg';
 import { MainContext } from '@/store';
 import { category, userName } from '@/utils/constants/header';
@@ -13,6 +14,8 @@ export default function Header() {
   const { loginToken } = useContext(MainContext);
   const { pathname } = useLocation();
   const [clickedIdNum, setClickedIdNum] = useState<number>(2);
+
+  onSlientRefresh();
 
   const handlePageMove = (item: categoryType) => {
     if (item.id === 2 || item.id === 3) {

--- a/src/components/media/MediaCategorySelector.tsx
+++ b/src/components/media/MediaCategorySelector.tsx
@@ -1,14 +1,20 @@
 import styled from '@emotion/styled';
-import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import useCategory from '@/hooks/useCategory';
+import useMediaCards from '@/hooks/useMediaCards';
 
-export default function MediaCategorySelector() {
+type MediaCategorySelectorPropsType = {
+  selectedCategory: string;
+  categoryChange: (title: string) => void;
+};
+
+export default function MediaCategorySelector({
+  selectedCategory,
+  categoryChange,
+}: MediaCategorySelectorPropsType) {
   const { categoryListData, isLoading, error } = useCategory();
-  const [selectedCategory, setSelectedCategory] = useState(
-    categoryListData?.categories[0].id
-  );
+  const { totalLinksCount } = useMediaCards();
   const navigate = useNavigate();
 
   const categoryMap: { [key: string]: number } = {};
@@ -25,11 +31,17 @@ export default function MediaCategorySelector() {
   return (
     <MediaCategorySelectorContainer>
       <CategoryTitle>
+        <CategoryItem
+          onClick={() => categoryChange('전체')}
+          className={selectedCategory === '전체' ? 'active' : ''}
+        >
+          {`전체(${totalLinksCount})`}
+        </CategoryItem>
         {categoryListData.categories.map((item, index) => {
           return (
             <CategoryItem
-              onClick={() => setSelectedCategory(item.id)}
-              className={selectedCategory === item.id ? 'active' : ''}
+              onClick={() => categoryChange(item.title)}
+              className={selectedCategory === item.title ? 'active' : ''}
               key={`${item.id}-${index}`}
             >
               {item.title}({categoryMap[item.title] || 0})

--- a/src/components/media/MediaListContainer.tsx
+++ b/src/components/media/MediaListContainer.tsx
@@ -9,8 +9,14 @@ import { getLinkUrlInfo } from '@/utils/validations/linkUtils';
 
 import Loading from '../Common/Loading';
 
-export default function MediaListContainer() {
-  const { mediaList, isLoading, error } = useMediaCards();
+type MediaListContainerPropType = {
+  selectedCategory: string;
+};
+
+export default function MediaListContainer({
+  selectedCategory,
+}: MediaListContainerPropType) {
+  const { mediaList, isLoading, error } = useMediaCards(selectedCategory);
   const [activeMediaCardInfo, setActiveMediaCardInfo] = useState<number>(0);
 
   const [isModalOpen, setIsModalOpen] = useState(false);

--- a/src/components/media/index.tsx
+++ b/src/components/media/index.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
 
 import { MainContext } from '@/store';
 
@@ -9,11 +9,17 @@ import MediaListContainer from './MediaListContainer';
 
 export default function Media() {
   const { mediaModalOpen, setMediaModalState } = useContext(MainContext);
-
+  const [selectedCategory, setSelectedCategory] = useState('전체');
+  const categoryChange = (title: string) => {
+    setSelectedCategory(title);
+  };
   return (
     <>
-      <MediaCategorySelector />
-      <MediaListContainer />
+      <MediaCategorySelector
+        selectedCategory={selectedCategory}
+        categoryChange={categoryChange}
+      />
+      <MediaListContainer selectedCategory={selectedCategory} />
       {mediaModalOpen && (
         <Modal
           width={940}

--- a/src/hooks/UseYoutubeVideo.tsx
+++ b/src/hooks/UseYoutubeVideo.tsx
@@ -15,9 +15,13 @@ export function useYoutubeVideo() {
   const [youtubeVideo, setYoutubeVideo] = useState<YoutubeVideo | null>(null);
   const handler = useCallback((youtubeVideoUrl: string | undefined) => {
     if (youtubeVideoUrl) {
-      fetchYoutubeVideo(extractVideoIdFromUrl(youtubeVideoUrl)).then(data => {
-        setYoutubeVideo(getYoutubeVideoFromMetadata(data.items[0]));
-      });
+      fetchYoutubeVideo(extractVideoIdFromUrl(youtubeVideoUrl))
+        .then(data => {
+          setYoutubeVideo(getYoutubeVideoFromMetadata(data.items[0]));
+        })
+        .catch(() => {
+          setYoutubeVideo(null);
+        });
     }
   }, []);
   return { youtubeVideo, handler };

--- a/src/hooks/useCategory.tsx
+++ b/src/hooks/useCategory.tsx
@@ -1,18 +1,14 @@
-import { useContext } from 'react';
 import useSWR from 'swr';
 
 import { getCategoryList } from '@/apis/Category';
-import { MainContext } from '@/store';
 import { CategoryListResponseDTO } from '@/types/category.interface';
 
 export default function useCategory() {
-  const { loginToken } = useContext(MainContext);
-
   const {
     data: categoryList,
     mutate,
     error,
-  } = useSWR<CategoryListResponseDTO, Error>([loginToken], getCategoryList);
+  } = useSWR<CategoryListResponseDTO, Error>('/getCategory', getCategoryList);
 
   return {
     categoryListData: categoryList,

--- a/src/hooks/useMediaCards.tsx
+++ b/src/hooks/useMediaCards.tsx
@@ -1,18 +1,13 @@
-import { useContext } from 'react';
 import useSWR from 'swr';
 
 import { getLinkList, LINK_URL } from '@/apis/Media';
-import { MainContext } from '@/store';
 import { GetLinkListResponse } from '@/types/media.interface';
 
 export default function useMediaCards(category?: string) {
-  const { loginToken } = useContext(MainContext);
-
-  const { data: mediaList, error } = useSWR<
-    GetLinkListResponse,
-    Error,
-    [string, string]
-  >([LINK_URL, loginToken], ([, accessToken]) => getLinkList(accessToken));
+  const { data: mediaList, error } = useSWR<GetLinkListResponse, Error>(
+    LINK_URL,
+    getLinkList
+  );
 
   return {
     mediaList:

--- a/src/hooks/useMediaCards.tsx
+++ b/src/hooks/useMediaCards.tsx
@@ -15,13 +15,15 @@ export default function useMediaCards(category?: string) {
   >([LINK_URL, loginToken], ([, accessToken]) => getLinkList(accessToken));
 
   return {
-    mediaList: category
-      ? mediaList?.archiveLinks.filter(link => {
-          link.category.title === category;
-        })
-      : mediaList?.archiveLinks,
+    mediaList:
+      category !== '전체'
+        ? mediaList?.archiveLinks.filter(
+            link => link.category.title === category
+          )
+        : mediaList?.archiveLinks,
 
     isLoading: !error && !mediaList,
     error: error,
+    totalLinksCount: mediaList?.archiveLinks.length,
   };
 }

--- a/src/hooks/useRecord.tsx
+++ b/src/hooks/useRecord.tsx
@@ -1,21 +1,14 @@
-import { useContext } from 'react';
 import useSWR from 'swr';
 
 import { recordListFetcher } from '@/apis/record';
-import { MainContext } from '@/store';
 import { recordListType } from '@/types/recordList.interface';
 
 export default function useRecord(category?: string) {
-  const { loginToken } = useContext(MainContext);
-
   const {
     data: recordList,
     mutate,
     error,
-  } = useSWR<recordListType, Error>(
-    ['record-templates', loginToken],
-    recordListFetcher
-  );
+  } = useSWR<recordListType, Error>('record-templates', recordListFetcher);
 
   const interviewCount = recordList?.filter(
     item => item.category === 'INTERVIEW'

--- a/src/hooks/useRecordDetail.tsx
+++ b/src/hooks/useRecordDetail.tsx
@@ -1,19 +1,15 @@
-import { useContext } from 'react';
 import useSWR from 'swr';
 
 import { recordDetailFetcher } from '@/apis/record';
-import { MainContext } from '@/store';
 import { recordDetailType } from '@/types/recordDetail.interface';
 
 export default function useRecordDetail(id: number) {
-  const { loginToken } = useContext(MainContext);
-
   const {
     data: recordDetailData,
     mutate,
     error,
   } = useSWR<recordDetailType, Error>(
-    [`record-templates/${id}`, loginToken],
+    `record-templates/${id}`,
     recordDetailFetcher
   );
 

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import React, { Dispatch, SetStateAction, useState } from 'react';
 
 import { Questions } from '@/types/question.interface';
 import { recordQuestionsType } from '@/types/recordDetail.interface';
@@ -6,7 +6,6 @@ import { Template } from '@/types/template.interface';
 import { categoryList, categoryListType } from '@/utils/constants/categoryList';
 
 type ContextType = {
-  loginToken: string;
   recordModalOpen: boolean;
   mediaModalOpen: boolean;
   selectedTemplateTitle: string;
@@ -23,7 +22,6 @@ type ContextType = {
   setStoredCategoryList: (storedCategoryList: categoryListType[]) => void;
   selectedRecordCard: string;
   setSelectedRecordCard: Dispatch<SetStateAction<string>>;
-  setLoginToken: Dispatch<SetStateAction<string>>;
   templateContent: Template | undefined;
   setTemplateContent: Dispatch<SetStateAction<Template | undefined>>;
   setSeletedRecordCardId: Dispatch<SetStateAction<number>>;
@@ -35,7 +33,6 @@ type ContextType = {
 };
 
 export const MainContext = React.createContext<ContextType>({
-  loginToken: '',
   questionList: [],
   storedCategoryList: [],
   recordModalOpen: false,
@@ -59,7 +56,6 @@ export const MainContext = React.createContext<ContextType>({
   setStoredCategoryList: () => {},
   selectedRecordCard: '',
   setSelectedRecordCard: () => {},
-  setLoginToken: () => {},
   setSeletedRecordCardId: () => {},
   setIsRecordEdit: () => {},
 
@@ -72,14 +68,6 @@ export const MainContext = React.createContext<ContextType>({
 export default function MainContextProvider(props: {
   children: React.ReactNode;
 }) {
-  const [loginToken, setLoginToken] = useState('');
-
-  useEffect(() => {
-    if (localStorage.getItem('token')) {
-      setLoginToken(localStorage.getItem('token')!);
-    }
-  }, [setLoginToken]);
-
   const [newQuestionList, setNewQuestionList] = useState<recordQuestionsType[]>(
     []
   );
@@ -97,9 +85,7 @@ export default function MainContextProvider(props: {
     useState<categoryListType[]>(categoryList);
   const [selectedIds, setSelectedIds] = useState<number[]>([]);
   const contextValue: ContextType = {
-    loginToken,
     questionList: storedQuestionList,
-
     recordModalOpen: recordModalState,
     setRecordModalState,
     mediaModalOpen: mediaModalState,
@@ -111,7 +97,6 @@ export default function MainContextProvider(props: {
     storedCategoryList,
     selectedRecordCard,
     setSelectedRecordCard,
-    setLoginToken,
     questions,
     setQuestions,
     templateContent,


### PR DESCRIPTION
## 💡 이슈 번호

close #83

## 📖 작업 내용

- [x] 화면이 렌더링 될때 마다 리프레쉬 토큰을 이용하여 토큰을 갱신
- [x] 14분마다 로그인토큰을 갱신
- [x] 로컬 스토리지에 리프레쉬 토큰이 없다면 => 로그인을 하지 않았다면 자동으로 login화면으로 넘어감
- [x] 액세스 토큰의 관리 장소를 context에서 axios로 변경
- [x] baseurl을 axios 인스턴스를 변경해서 따로 호출하지 않고 사용할수있게 해두었음

## ✅ PR 포인트

- 봐야하는 부분
로그인 토큰을 axios를 이용해서 관리하게 조정하였습니다. 이제 axios를 쓸때 base url이랑 header에 액세스 토큰 따로 받아와서 넣어줄 필요없이 그냥 /api/v1 이후의 주소만 입력하면 됩니다.
로컬 스토리지에는 이제 리프레쉬토큰만 제공됩니다.

## 📸 스크린샷

![image](https://github.com/pie-sfac/5-17-smokedDuck/assets/104823768/692749e4-32f3-4577-8e5c-1a027c5c5f01)

![PieHealthcare - Chrome 2023-08-05 02-48-41](https://github.com/pie-sfac/5-17-smokedDuck/assets/104823768/ea263ba5-3b33-48ef-b37c-baa93e182bdd)
![PieHealthcare - Chrome 2023-08-05 02-47-51](https://github.com/pie-sfac/5-17-smokedDuck/assets/104823768/cac99f0c-68dc-405b-88b0-6807b4a087e7)
