### PR TITLE
feat: 카테고리별 링크 카드 필터링

### DIFF
--- a/src/components/media/MediaCategorySelector.tsx
+++ b/src/components/media/MediaCategorySelector.tsx
@@ -1,14 +1,20 @@
 import styled from '@emotion/styled';
-import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import useCategory from '@/hooks/useCategory';
+import useMediaCards from '@/hooks/useMediaCards';
 
-export default function MediaCategorySelector() {
+type MediaCategorySelectorPropsType = {
+  selectedCategory: string;
+  categoryChange: (title: string) => void;
+};
+
+export default function MediaCategorySelector({
+  selectedCategory,
+  categoryChange,
+}: MediaCategorySelectorPropsType) {
   const { categoryListData, isLoading, error } = useCategory();
-  const [selectedCategory, setSelectedCategory] = useState(
-    categoryListData?.categories[0].id
-  );
+  const { totalLinksCount } = useMediaCards();
   const navigate = useNavigate();
 
   const categoryMap: { [key: string]: number } = {};
@@ -25,11 +31,17 @@ export default function MediaCategorySelector() {
   return (
     <MediaCategorySelectorContainer>
       <CategoryTitle>
+        <CategoryItem
+          onClick={() => categoryChange('전체')}
+          className={selectedCategory === '전체' ? 'active' : ''}
+        >
+          {`전체(${totalLinksCount})`}
+        </CategoryItem>
         {categoryListData.categories.map((item, index) => {
           return (
             <CategoryItem
-              onClick={() => setSelectedCategory(item.id)}
-              className={selectedCategory === item.id ? 'active' : ''}
+              onClick={() => categoryChange(item.title)}
+              className={selectedCategory === item.title ? 'active' : ''}
               key={`${item.id}-${index}`}
             >
               {item.title}({categoryMap[item.title] || 0})

--- a/src/components/media/MediaListContainer.tsx
+++ b/src/components/media/MediaListContainer.tsx
@@ -9,8 +9,14 @@ import { getLinkUrlInfo } from '@/utils/validations/linkUtils';
 
 import Loading from '../Common/Loading';
 
-export default function MediaListContainer() {
-  const { mediaList, isLoading, error } = useMediaCards();
+type MediaListContainerPropType = {
+  selectedCategory: string;
+};
+
+export default function MediaListContainer({
+  selectedCategory,
+}: MediaListContainerPropType) {
+  const { mediaList, isLoading, error } = useMediaCards(selectedCategory);
   const [activeMediaCardInfo, setActiveMediaCardInfo] = useState<number>(0);
 
   const [isModalOpen, setIsModalOpen] = useState(false);

--- a/src/components/media/index.tsx
+++ b/src/components/media/index.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
 
 import { MainContext } from '@/store';
 
@@ -9,11 +9,17 @@ import MediaListContainer from './MediaListContainer';
 
 export default function Media() {
   const { mediaModalOpen, setMediaModalState } = useContext(MainContext);
-
+  const [selectedCategory, setSelectedCategory] = useState('전체');
+  const categoryChange = (title: string) => {
+    setSelectedCategory(title);
+  };
   return (
     <>
-      <MediaCategorySelector />
-      <MediaListContainer />
+      <MediaCategorySelector
+        selectedCategory={selectedCategory}
+        categoryChange={categoryChange}
+      />
+      <MediaListContainer selectedCategory={selectedCategory} />
       {mediaModalOpen && (
         <Modal
           width={940}

--- a/src/hooks/useMediaCards.tsx
+++ b/src/hooks/useMediaCards.tsx
@@ -15,13 +15,15 @@ export default function useMediaCards(category?: string) {
   >([LINK_URL, loginToken], ([, accessToken]) => getLinkList(accessToken));
 
   return {
-    mediaList: category
-      ? mediaList?.archiveLinks.filter(link => {
-          link.category.title === category;
-        })
-      : mediaList?.archiveLinks,
+    mediaList:
+      category !== '전체'
+        ? mediaList?.archiveLinks.filter(
+            link => link.category.title === category
+          )
+        : mediaList?.archiveLinks,
 
     isLoading: !error && !mediaList,
     error: error,
+    totalLinksCount: mediaList?.archiveLinks.length,
   };
 }


### PR DESCRIPTION
## 💡 이슈 번호

close #85 

## 📖 작업 내용

- [x] 선택된 카테고리별로 링크 카드 필터링해서 렌더링
 -[x] 전체 카테고리 항목 추가

## ✅ PR 포인트
카테고리에 "전체" 항목을 추가했어요
카테고리 편집 페이지에서는 "전체" 항목이 보이지않아요 ( 편집할 필요가 없기 때문)

## 📸 스크린샷
![PieHealthcare - Chrome 2023-08-05 03-17-42](https://github.com/pie-sfac/5-17-smokedDuck/assets/104823768/a9b339be-4a1b-4769-94f0-2596ca50bf28)