### PR TITLE
refactor: 템플릿 생성 시 미디어 추가 버튼 및 기능 제거

### DIFF
--- a/src/components/Question/QuestionContent.tsx
+++ b/src/components/Question/QuestionContent.tsx
@@ -1,7 +1,5 @@
 import styled from '@emotion/styled';
-import { ChangeEvent, useCallback, useRef, useState } from 'react';
-
-import { AddedFile } from '@/types/question.interface';
+import { useCallback, useState } from 'react';
 
 type QuestionContentProps = {
   onChange: (
@@ -26,7 +24,6 @@ export default function QuestionContent({
   onChange,
   currentQuestion,
 }: QuestionContentProps) {
-  const [addedFiles, setAddedFiles] = useState<AddedFile[]>([]);
   const [currentSelection, setCurrentSelection] = useState('');
   const [addedSelections, setAddedSelections] = useState<string[]>([]);
 
@@ -36,47 +33,6 @@ export default function QuestionContent({
   );
   const [currentOptions, setCurrentOptions] = useState<string[] | undefined>(
     currentQuestion ? currentQuestion.options : []
-  );
-
-  const fileInputRef = useRef<HTMLInputElement>(null);
-
-  const clickMediaAttatchmentButton = useCallback(() => {
-    if (fileInputRef !== null && fileInputRef.current) {
-      fileInputRef.current.click();
-    }
-  }, []);
-
-  const handleAddedFile = useCallback(
-    async (e: ChangeEvent<HTMLInputElement>) => {
-      if (e.target.files !== undefined && e.target.files !== null) {
-        const currFile = e.target.files[0];
-        const currFileName = currFile.name;
-
-        const promise = new Promise(
-          (resolve: (arg: string | ArrayBuffer | null) => void) => {
-            const reader = new FileReader();
-
-            reader.readAsDataURL(currFile);
-            reader.onload = function () {
-              resolve(reader.result);
-            };
-          }
-        );
-
-        await promise.then(value => {
-          const createdFile = {
-            _id:
-              addedFiles.length === 0
-                ? 1
-                : addedFiles[addedFiles.length - 1]._id + 1,
-            path: value,
-            filename: currFileName,
-          };
-          setAddedFiles(prevAddedFiles => [...prevAddedFiles, createdFile]);
-        });
-      }
-    },
-    [addedFiles]
   );
 
   const handleAddedSelections = useCallback(
@@ -146,50 +102,7 @@ export default function QuestionContent({
       />
       {currentQuestion.title === '미디어' && (
         <AddMediaContainer>
-          <AddMediaButton
-            htmlFor="mediaFile"
-            onClickCapture={e => {
-              e.stopPropagation();
-            }}
-            onClick={clickMediaAttatchmentButton}
-          >
-            + 답변자 미디어 첨부
-            <input
-              type="file"
-              name="mediaFile"
-              id="mediaFile"
-              accept="image/*, video/*"
-              onChange={e => {
-                addedFiles.length >= 6
-                  ? alert('미디어는 6개까지 첨부 가능합니다.')
-                  : handleAddedFile(e);
-              }}
-              style={{ display: 'none' }}
-              ref={fileInputRef}
-            />
-          </AddMediaButton>
-          {addedFiles.length !== 0 && (
-            <AddedFileContainer>
-              {addedFiles &&
-                addedFiles.map(addedFile => (
-                  <div key={addedFile._id}>
-                    <ChangeMediaButton
-                      onClick={() => {
-                        setAddedFiles(prevAddedFiles =>
-                          prevAddedFiles.filter(
-                            prevAddedFile => prevAddedFile._id !== addedFile._id
-                          )
-                        );
-                        clickMediaAttatchmentButton();
-                      }}
-                    >
-                      파일 변경
-                    </ChangeMediaButton>
-                    {addedFile.filename}
-                  </div>
-                ))}
-            </AddedFileContainer>
-          )}
+          * 답변자 미디어를 첨부할 수 있습니다.
         </AddMediaContainer>
       )}
       {currentQuestion.title === '선택형' && (
@@ -296,35 +209,9 @@ const StyledTextArea = styled('textarea')`
 const AddMediaContainer = styled('div')`
   display: flex;
   align-items: center;
-`;
-
-const AddMediaButton = styled('label')`
-  width: 18rem;
-  height: 2.4rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  color: #aeaeae;
   font-size: 0.8rem;
-  font-weight: normal;
-  background-color: rgba(244, 244, 244, 0.5);
-  border: 1px dashed #cfcfcf;
-  border-radius: 10px 10px 10px 10px;
-  margin: 0.5rem 0.5rem 0.5rem 0;
-  :hover {
-    cursor: pointer;
-  }
-`;
-
-const AddedFileContainer = styled('div')`
-  height: 3rem;
-  width: 70%;
-  display: flex;
-  flex-direction: column;
-  overflow-y: scroll;
-
-  &::-webkit-scrollbar {
-    display: none;
-  }
+  margin: 0.2rem;
 `;
 
 const ChangeMediaButton = styled('button')`

--- a/src/components/RecordDetailItem/RecordDetailItemContent.tsx
+++ b/src/components/RecordDetailItem/RecordDetailItemContent.tsx
@@ -1,8 +1,6 @@
 import styled from '@emotion/styled';
-import { ChangeEvent, useCallback, useRef, useState } from 'react';
 
 import RecordDetailCheckOutSelection from '@/components/RecordDetailItem/RecordDetailCheckOutSelection';
-import { AddedFile } from '@/types/question.interface';
 
 type QuestionContentProps = {
   title: string;
@@ -19,51 +17,6 @@ export default function QuestionContent({
   type,
   isRecordEdit,
 }: QuestionContentProps) {
-  const [addedFiles, setAddedFiles] = useState<AddedFile[]>([]);
-
-  const fileInputRef = useRef<HTMLInputElement>(null);
-
-  const clickMediaAttatchmentButton = useCallback(() => {
-    if (fileInputRef !== null && fileInputRef.current) {
-      fileInputRef.current.click();
-    }
-  }, []);
-
-  const handleAddedFile = useCallback(
-    async (e: ChangeEvent<HTMLInputElement>) => {
-      if (e.target.files !== undefined && e.target.files !== null) {
-        const currFile = e.target.files[0];
-        const currFileName = currFile.name;
-
-        const promise = new Promise(
-          (resolve: (arg: string | ArrayBuffer | null) => void) => {
-            const reader = new FileReader();
-
-            reader.readAsDataURL(currFile);
-            reader.onload = function () {
-              resolve(reader.result);
-            };
-          }
-        );
-
-        await promise.then(value => {
-          setAddedFiles(prevAddedFiles => [
-            ...prevAddedFiles,
-            {
-              _id:
-                prevAddedFiles.length === 0
-                  ? 1
-                  : prevAddedFiles[prevAddedFiles.length - 1]._id + 1,
-              path: value,
-              filename: currFileName,
-            },
-          ]);
-        });
-      }
-    },
-    []
-  );
-
   return (
     <QuestionContentContainer>
       <StyledLabel htmlFor="questionTitle">문항 제목</StyledLabel>
@@ -94,50 +47,7 @@ export default function QuestionContent({
       />
       {type === 'MEDIA' && (
         <AddMediaContainer>
-          <AddMediaButton
-            htmlFor="mediaFile"
-            onClickCapture={e => {
-              e.stopPropagation();
-            }}
-            onClick={clickMediaAttatchmentButton}
-          >
-            + 답변자 미디어 첨부
-            <input
-              type="file"
-              name="mediaFile"
-              id="mediaFile"
-              accept="image/*, video/*"
-              onChange={e => {
-                addedFiles.length >= 6
-                  ? alert('미디어는 6개까지 첨부 가능합니다.')
-                  : handleAddedFile(e);
-              }}
-              style={{ display: 'none' }}
-              ref={fileInputRef}
-            />
-          </AddMediaButton>
-          {addedFiles.length !== 0 && (
-            <AddedFileContainer>
-              {addedFiles &&
-                addedFiles.map(addedFile => (
-                  <div key={addedFile._id}>
-                    <ChangeMediaButton
-                      onClick={() => {
-                        setAddedFiles(prevAddedFiles =>
-                          prevAddedFiles.filter(
-                            prevAddedFile => prevAddedFile._id !== addedFile._id
-                          )
-                        );
-                        clickMediaAttatchmentButton();
-                      }}
-                    >
-                      파일 변경
-                    </ChangeMediaButton>
-                    {addedFile.filename}
-                  </div>
-                ))}
-            </AddedFileContainer>
-          )}
+          * 답변자 미디어를 첨부할 수 있습니다.
         </AddMediaContainer>
       )}
       {type === 'SELECT' && <RecordDetailCheckOutSelection options={options} />}
@@ -181,42 +91,7 @@ const StyledTextArea = styled('textarea')`
 const AddMediaContainer = styled('div')`
   display: flex;
   align-items: center;
-`;
-
-const AddMediaButton = styled('label')`
-  width: 18rem;
-  height: 2.4rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  color: #aeaeae;
   font-size: 0.8rem;
-  font-weight: normal;
-  background-color: rgba(244, 244, 244, 0.5);
-  border: 1px dashed #cfcfcf;
-  border-radius: 10px 10px 10px 10px;
-  margin: 0.5rem 0.5rem 0.5rem 0;
-  :hover {
-    cursor: pointer;
-  }
-`;
-
-const AddedFileContainer = styled('div')`
-  height: 3rem;
-  width: 70%;
-  display: flex;
-  flex-direction: column;
-  overflow-y: scroll;
-
-  &::-webkit-scrollbar {
-    display: none;
-  }
-`;
-
-const ChangeMediaButton = styled('button')`
-  background-color: #ebf1ff;
-  font-weight: normal;
-  font-size: 0.5rem;
-  margin-right: 0.4rem;
-  padding: 0.3rem;
-  border-radius: 10px 10px 10px 10px;
+  margin: 0.2rem;
 `;


### PR DESCRIPTION
## 💡 이슈 번호

close #91 

## 📖 작업 내용

- [X] 템플릿 생성 시 미디어 추가 버튼 및 기능 제거
- [X] 알림 문구로 대체

## ✅ PR 포인트

- 템플릿 생성 시 미디어 문항의 미디어 추가 버튼과 기능을 제거했어요.
- 템플릿 조회 시 나타나는 미디어 문항의 미디어 추가 버튼과 기능을 제거했어요.

## 📸 스크린샷
![image](https://github.com/pie-sfac/5-17-smokedDuck/assets/33304871/93354bc0-40c8-4e71-860c-dee3e4b8a9fc)
![image](https://github.com/pie-sfac/5-17-smokedDuck/assets/33304871/5faa73e7-4bcf-4291-921b-ef79ec64b316)
