### PR TITLE
feat: 템플릿 생성 validate 추가

### DIFF
--- a/src/components/Question/QuestionOptionalContent.tsx
+++ b/src/components/Question/QuestionOptionalContent.tsx
@@ -18,21 +18,16 @@ export default function QuestionOptionalContent({
   type,
   onChange,
 }: QuestionOptionalContentProps) {
-  const [currentOptions, setCurrentOptions] = useState(options);
+  const [currentOptions, setCurrentOptions] = useState<string[] | undefined>(
+    options
+  );
   const [currentSelection, setCurrentSelection] = useState('');
 
   const handleAddedOptions = useCallback(
     (currentSelection: string) => {
-      setCurrentOptions(prevCurrentOptions => [
-        ...(prevCurrentOptions || []),
-        currentSelection,
-      ]);
-
-      currentOptions?.length !== 0 &&
-        onChange(order, 'options', [
-          ...(currentOptions || []),
-          currentSelection,
-        ]);
+      const newAddedOptions = [...(currentOptions || []), currentSelection];
+      setCurrentOptions(newAddedOptions);
+      onChange(order, 'options', newAddedOptions);
       setCurrentSelection('');
     },
     [currentOptions, onChange, order]
@@ -44,8 +39,9 @@ export default function QuestionOptionalContent({
         (_, idx) => targetId !== idx
       );
       setCurrentOptions(deletedOptions);
+      deletedOptions && onChange(order, 'options', deletedOptions);
     },
-    [currentOptions]
+    [currentOptions, onChange, order]
   );
 
   return (

--- a/src/components/Question/index.tsx
+++ b/src/components/Question/index.tsx
@@ -8,6 +8,13 @@ import QuestionContent from './QuestionContent';
 import QuestionFooter from './QuestionFooter';
 import QuestionHeader from './QuestionHeader';
 import QuestionOptionalContent from './QuestionOptionalContent';
+
+type checkedSpecialQuestions = {
+  isPAIN_HSTRY: boolean;
+  isCONDITION: boolean;
+  isPAIN_INTV: boolean;
+};
+
 interface QuestionProps {
   onChange: (
     order: number,
@@ -15,9 +22,16 @@ interface QuestionProps {
     value: string | string[] | boolean
   ) => void;
   question: Questions;
+  setIsCheckedSpecialQuestions: React.Dispatch<
+    React.SetStateAction<checkedSpecialQuestions>
+  >;
 }
 
-export default function Question({ onChange, question }: QuestionProps) {
+export default function Question({
+  onChange,
+  question,
+  setIsCheckedSpecialQuestions,
+}: QuestionProps) {
   const { questionList, setQuestionList } = useContext(MainContext);
 
   const handleClickedMoveButton = useCallback(
@@ -62,6 +76,25 @@ export default function Question({ onChange, question }: QuestionProps) {
 
   const handleClickedDeleteButton = useCallback(
     (order: number) => {
+      const targetDeleteQuestion = questionList.filter(
+        question => question.order === order
+      );
+      if (targetDeleteQuestion[0].type === 'PAIN_HSTRY') {
+        setIsCheckedSpecialQuestions(prevIsChecked => ({
+          ...prevIsChecked,
+          isPAIN_HSTRY: false,
+        }));
+      } else if (targetDeleteQuestion[0].type === 'CONDITION') {
+        setIsCheckedSpecialQuestions(prevIsChecked => ({
+          ...prevIsChecked,
+          isCONDITION: false,
+        }));
+      } else if (targetDeleteQuestion[0].type === 'PAIN_INTV') {
+        setIsCheckedSpecialQuestions(prevIsChecked => ({
+          ...prevIsChecked,
+          isPAIN_INTV: false,
+        }));
+      }
       const deletedQuestions = questionList.filter(
         question => question.order !== order
       );
@@ -70,7 +103,7 @@ export default function Question({ onChange, question }: QuestionProps) {
       });
       setQuestionList(deletedQuestions);
     },
-    [questionList, setQuestionList]
+    [questionList, setIsCheckedSpecialQuestions, setQuestionList]
   );
 
   const isBasic = ['TEXT', 'MEDIA', 'SELECT'].includes(question.type);

--- a/src/components/Template/TemplateContent.tsx
+++ b/src/components/Template/TemplateContent.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useContext } from 'react';
+import { Dispatch, SetStateAction, useContext, useState } from 'react';
 
 import { MainContext } from '@/store';
 import { Questions } from '@/types/question.interface';
@@ -16,12 +16,26 @@ type TemplateContentProps = {
   onChange: (id: string, value: string | Questions[]) => void;
 };
 
+type checkedSpecialQuestions = {
+  isPAIN_HSTRY: boolean;
+  isCONDITION: boolean;
+  isPAIN_INTV: boolean;
+};
+
 export default function TemplateContent({
   currTemplateSubHeader,
   setCurrTemplateSubHeader,
   onChange,
 }: TemplateContentProps) {
   const { selectedTemplateTitle } = useContext(MainContext);
+
+  const [isCheckedSpecialQuestions, setIsCheckedSpecialQuestions] =
+    useState<checkedSpecialQuestions>({
+      isPAIN_HSTRY: false,
+      isCONDITION: false,
+      isPAIN_INTV: false,
+    });
+
   return (
     <div>
       {selectedTemplateTitle.length === 0 ? (
@@ -33,8 +47,14 @@ export default function TemplateContent({
             setCurrTemplateSubHeader={setCurrTemplateSubHeader}
             onChange={onChange}
           />
-          <TemplateQuestionSelections />
-          <TemplateSelectedQuestionContainer />
+          <TemplateQuestionSelections
+            isCheckedSpecialQuestions={isCheckedSpecialQuestions}
+            setIsCheckedSpecialQuestions={setIsCheckedSpecialQuestions}
+          />
+          <TemplateSelectedQuestionContainer
+            isCheckedSpecialQuestions={isCheckedSpecialQuestions}
+            setIsCheckedSpecialQuestions={setIsCheckedSpecialQuestions}
+          />
         </>
       )}
     </div>

--- a/src/components/Template/TemplateContent.tsx
+++ b/src/components/Template/TemplateContent.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useContext } from 'react';
+import { Dispatch, SetStateAction, useContext, useState } from 'react';
 
 import { MainContext } from '@/store';
 import { Questions } from '@/types/question.interface';
@@ -16,12 +16,25 @@ type TemplateContentProps = {
   onChange: (id: string, value: string | Questions[]) => void;
 };
 
+type checkedSpecialQuestions = {
+  isPAIN_HSTRY: boolean;
+  isCONDITION: boolean;
+  isPAIN_INTV: boolean;
+};
+
 export default function TemplateContent({
   currTemplateSubHeader,
   setCurrTemplateSubHeader,
   onChange,
 }: TemplateContentProps) {
   const { selectedTemplateTitle } = useContext(MainContext);
+
+  const [isCheckedSpecialQuestions, setIsCheckedSpecialQuestions] =
+    useState<checkedSpecialQuestions>({
+      isPAIN_HSTRY: false,
+      isCONDITION: false,
+      isPAIN_INTV: false,
+    });
 
   return (
     <div>
@@ -34,8 +47,14 @@ export default function TemplateContent({
             setCurrTemplateSubHeader={setCurrTemplateSubHeader}
             onChange={onChange}
           />
-          <TemplateQuestionSelections />
-          <TemplateSelectedQuestionContainer />
+          <TemplateQuestionSelections
+            isCheckedSpecialQuestions={isCheckedSpecialQuestions}
+            setIsCheckedSpecialQuestions={setIsCheckedSpecialQuestions}
+          />
+          <TemplateSelectedQuestionContainer
+            isCheckedSpecialQuestions={isCheckedSpecialQuestions}
+            setIsCheckedSpecialQuestions={setIsCheckedSpecialQuestions}
+          />
         </>
       )}
     </div>

--- a/src/components/Template/TemplateFooter.tsx
+++ b/src/components/Template/TemplateFooter.tsx
@@ -5,13 +5,13 @@ import { useContext } from 'react';
 import { MainContext } from '@/store';
 
 type TemplateFooterProps = {
-  handleClickedSaveButton: (id?: number) => Promise<void>;
+  handleClickedSaveButton: () => void;
 };
 
 export default function TemplateFooter({
   handleClickedSaveButton,
 }: TemplateFooterProps) {
-  const { selectedRecordCard, questionList } = useContext(MainContext);
+  const { questionList } = useContext(MainContext);
 
   return (
     <FooterContainer>
@@ -23,7 +23,7 @@ export default function TemplateFooter({
         }}
         borderRadius={'20px 20px 20px 20px'}
         isDisabled={questionList.length < 1 ? true : false}
-        onClick={() => handleClickedSaveButton(selectedRecordCard?.id)}
+        onClick={handleClickedSaveButton}
       >
         저장
       </Button>

--- a/src/components/Template/TemplateQuestionSelections.tsx
+++ b/src/components/Template/TemplateQuestionSelections.tsx
@@ -11,8 +11,25 @@ import Text from '@/assets/Text.svg';
 
 import QuestionBox from '../Common/QuestionBox';
 
-export default function TemplateQuestionSelections() {
+type checkedSpecialQuestions = {
+  isPAIN_HSTRY: boolean;
+  isCONDITION: boolean;
+  isPAIN_INTV: boolean;
+};
+
+type TemplateQuestionSelectionsProps = {
+  isCheckedSpecialQuestions: checkedSpecialQuestions;
+  setIsCheckedSpecialQuestions: React.Dispatch<
+    React.SetStateAction<checkedSpecialQuestions>
+  >;
+};
+
+export default function TemplateQuestionSelections({
+  isCheckedSpecialQuestions,
+  setIsCheckedSpecialQuestions,
+}: TemplateQuestionSelectionsProps) {
   const [selectedQuestion, setSelectedQuestion] = useState('');
+
   return (
     <EntireQuestionContainer>
       <QeustionsContainer>
@@ -89,6 +106,8 @@ export default function TemplateQuestionSelections() {
             tagName={'전문'}
             margin={'0.4rem'}
             type={'PAIN_HSTRY'}
+            isCheckedSpecialQuestions={isCheckedSpecialQuestions}
+            setIsCheckedSpecialQuestions={setIsCheckedSpecialQuestions}
           />
           <QuestionBox
             image={Condition}
@@ -97,6 +116,8 @@ export default function TemplateQuestionSelections() {
             tagName={'전문'}
             margin={'0.4rem'}
             type={'CONDITION'}
+            isCheckedSpecialQuestions={isCheckedSpecialQuestions}
+            setIsCheckedSpecialQuestions={setIsCheckedSpecialQuestions}
           />
           <QuestionBox
             image={PainQuestion}
@@ -106,6 +127,8 @@ export default function TemplateQuestionSelections() {
             }
             tagName={'전문'}
             type={'PAIN_INTV'}
+            isCheckedSpecialQuestions={isCheckedSpecialQuestions}
+            setIsCheckedSpecialQuestions={setIsCheckedSpecialQuestions}
           />
         </QuestionBoxContainer>
       )}

--- a/src/components/Template/TemplateQuestionSelections.tsx
+++ b/src/components/Template/TemplateQuestionSelections.tsx
@@ -1,6 +1,6 @@
 import { Box } from '@chakra-ui/react';
 import styled from '@emotion/styled';
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 
 import Condition from '@/assets/Condition.svg';
 import Media from '@/assets/Media.svg';
@@ -8,6 +8,7 @@ import Pain from '@/assets/Pain.svg';
 import PainQuestion from '@/assets/PainQuestion.svg';
 import Selections from '@/assets/Selections.svg';
 import Text from '@/assets/Text.svg';
+import { MainContext } from '@/store';
 
 import QuestionBox from '../Common/QuestionBox';
 
@@ -28,6 +29,7 @@ export default function TemplateQuestionSelections({
   isCheckedSpecialQuestions,
   setIsCheckedSpecialQuestions,
 }: TemplateQuestionSelectionsProps) {
+  const { selectedTemplateTitle } = useContext(MainContext);
   const [selectedQuestion, setSelectedQuestion] = useState('');
 
   return (
@@ -97,41 +99,47 @@ export default function TemplateQuestionSelections({
           />
         </QuestionBoxContainer>
       )}
-      {selectedQuestion === 'specialty' && (
-        <QuestionBoxContainer>
-          <QuestionBox
-            image={Pain}
-            tagTitle={'통증 정도'}
-            description={'회원의 통증 정도를 선택하는 문항입니다.'}
-            tagName={'전문'}
-            margin={'0.4rem'}
-            type={'PAIN_HSTRY'}
-            isCheckedSpecialQuestions={isCheckedSpecialQuestions}
-            setIsCheckedSpecialQuestions={setIsCheckedSpecialQuestions}
-          />
-          <QuestionBox
-            image={Condition}
-            tagTitle={'오늘의 컨디션'}
-            description={'회원의 컨디션 정도를 선택하는 문항입니다.'}
-            tagName={'전문'}
-            margin={'0.4rem'}
-            type={'CONDITION'}
-            isCheckedSpecialQuestions={isCheckedSpecialQuestions}
-            setIsCheckedSpecialQuestions={setIsCheckedSpecialQuestions}
-          />
-          <QuestionBox
-            image={PainQuestion}
-            tagTitle={'통증 문진'}
-            description={
-              '통증 부위, 유형, 정도, 빈도, 기간을 작성할 수 있는 문항입니다.'
-            }
-            tagName={'전문'}
-            type={'PAIN_INTV'}
-            isCheckedSpecialQuestions={isCheckedSpecialQuestions}
-            setIsCheckedSpecialQuestions={setIsCheckedSpecialQuestions}
-          />
-        </QuestionBoxContainer>
-      )}
+      {selectedQuestion === 'specialty' &&
+        selectedTemplateTitle === '문진 템플릿' && (
+          <QuestionBoxContainer>
+            <QuestionBox
+              image={PainQuestion}
+              tagTitle={'통증 문진'}
+              description={
+                '통증 부위, 유형, 정도, 빈도, 기간을 작성할 수 있는 문항입니다.'
+              }
+              tagName={'전문'}
+              type={'PAIN_INTV'}
+              isCheckedSpecialQuestions={isCheckedSpecialQuestions}
+              setIsCheckedSpecialQuestions={setIsCheckedSpecialQuestions}
+            />
+          </QuestionBoxContainer>
+        )}
+      {selectedQuestion === 'specialty' &&
+        selectedTemplateTitle === '처치 템플릿' && (
+          <QuestionBoxContainer>
+            <QuestionBox
+              image={Pain}
+              tagTitle={'통증 정도'}
+              description={'회원의 통증 정도를 선택하는 문항입니다.'}
+              tagName={'전문'}
+              margin={'0.4rem'}
+              type={'PAIN_HSTRY'}
+              isCheckedSpecialQuestions={isCheckedSpecialQuestions}
+              setIsCheckedSpecialQuestions={setIsCheckedSpecialQuestions}
+            />
+            <QuestionBox
+              image={Condition}
+              tagTitle={'오늘의 컨디션'}
+              description={'회원의 컨디션 정도를 선택하는 문항입니다.'}
+              tagName={'전문'}
+              margin={'0.4rem'}
+              type={'CONDITION'}
+              isCheckedSpecialQuestions={isCheckedSpecialQuestions}
+              setIsCheckedSpecialQuestions={setIsCheckedSpecialQuestions}
+            />
+          </QuestionBoxContainer>
+        )}
     </EntireQuestionContainer>
   );
 }
@@ -149,5 +157,4 @@ const QeustionsContainer = styled('div')`
 const QuestionBoxContainer = styled('div')`
   display: flex;
   margin: 0 2rem 0 2rem;
-  justify-content: space-between;
 `;

--- a/src/components/Template/TemplateSelectedQuestionContainer.tsx
+++ b/src/components/Template/TemplateSelectedQuestionContainer.tsx
@@ -6,7 +6,22 @@ import { MainContext } from '@/store';
 
 import Question from '../Question';
 
-export default function TemplateSelectedQuestionContainer() {
+type checkedSpecialQuestions = {
+  isPAIN_HSTRY: boolean;
+  isCONDITION: boolean;
+  isPAIN_INTV: boolean;
+};
+
+type TemplateSelectedQuestionContainerProps = {
+  isCheckedSpecialQuestions: checkedSpecialQuestions;
+  setIsCheckedSpecialQuestions: React.Dispatch<
+    React.SetStateAction<checkedSpecialQuestions>
+  >;
+};
+
+export default function TemplateSelectedQuestionContainer({
+  setIsCheckedSpecialQuestions,
+}: TemplateSelectedQuestionContainerProps) {
   const { questionList, setQuestionList } = useContext(MainContext);
 
   const handleQuestionContent = useCallback(
@@ -61,6 +76,7 @@ export default function TemplateSelectedQuestionContainer() {
             }
             question={question}
             onChange={handleQuestionContent}
+            setIsCheckedSpecialQuestions={setIsCheckedSpecialQuestions}
           />
         ))
       )}

--- a/src/components/Template/index.tsx
+++ b/src/components/Template/index.tsx
@@ -70,7 +70,7 @@ export default function Template() {
       return;
     }
     questionList.map(question => {
-      if (question.title.length === 0) {
+      if (question.tagName === '기본' && question.title.length === 0) {
         alert(`${setTitle(question.type)} 문항의 제목을 입력해주세요.`);
         return;
       }

--- a/src/components/Template/index.tsx
+++ b/src/components/Template/index.tsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from 'react';
+import { useCallback, useContext, useState } from 'react';
 import { mutate } from 'swr';
 
 import { createTemplate } from '@/apis/Template';
@@ -33,6 +33,29 @@ export default function Template() {
     description: selectedRecordCard ? selectedRecordCard.description : '',
   });
 
+  const setTitle = useCallback((type: string) => {
+    switch (type) {
+      case 'PAIN_HSTRY':
+        return '통증 정도';
+        break;
+      case 'CONDITION':
+        return '오늘의 컨디션';
+        break;
+      case 'PAIN_INTV':
+        return '통증 문진';
+        break;
+      case 'TEXT':
+        return '텍스트';
+        break;
+      case 'SELECT':
+        return '선택형';
+        break;
+      case 'MEDIA':
+        return '미디어';
+        break;
+    }
+  }, []);
+
   const handleTemplateContent = (id: string, value: string | Questions[]) => {
     templateContent &&
       setTemplateContent({
@@ -42,7 +65,15 @@ export default function Template() {
   };
 
   const handleClickedSaveButton = async () => {
+    if (templateContent?.title.length === 0) {
+      alert('템플릿 제목을 입력해주세요.');
+      return;
+    }
     questionList.map(question => {
+      if (question.title.length === 0) {
+        alert(`${setTitle(question.type)} 문항의 제목을 입력해주세요.`);
+        return;
+      }
       if (question.type === 'SELECT') {
         if (question.options?.length === 0) {
           alert('선택형 문항의 보기가 존재하지 않습니다.');

--- a/src/components/Template/index.tsx
+++ b/src/components/Template/index.tsx
@@ -42,6 +42,23 @@ export default function Template() {
   };
 
   const handleClickedSaveButton = async () => {
+    questionList.map(question => {
+      if (question.type === 'SELECT') {
+        if (question.options?.length === 0) {
+          alert('선택형 문항의 보기가 존재하지 않습니다.');
+          return;
+        } else {
+          const set = new Set(question.options);
+          if (set.size !== question.options?.length) {
+            alert(
+              '작성하신 선택형 문항의 보기 중 중복값이 존재합니다. 중복을 수정해주세요.'
+            );
+            return;
+          }
+        }
+      }
+    });
+
     const newTemplateContent: NewTemplateContent = {
       ...templateContent,
       questions: questionList,

--- a/src/components/common/QuestionBox.tsx
+++ b/src/components/common/QuestionBox.tsx
@@ -27,6 +27,10 @@ export default function QuestionBox({
         marginRight: margin,
       }}
       onClick={() => {
+        if (questionList.length === 30) {
+          alert('템플릿당 문항수는 30개를 초과할 수 없습니다.');
+          return;
+        }
         setQuestionList([
           ...questionList,
           {

--- a/src/components/common/QuestionBox.tsx
+++ b/src/components/common/QuestionBox.tsx
@@ -3,6 +3,13 @@ import { useContext } from 'react';
 
 import { MainContext } from '@/store';
 
+type checkedSpecialQuestions = {
+  [key: string]: boolean;
+  isPAIN_HSTRY: boolean;
+  isCONDITION: boolean;
+  isPAIN_INTV: boolean;
+};
+
 type QuestionBoxProps = {
   image: string;
   tagTitle: string;
@@ -10,7 +17,12 @@ type QuestionBoxProps = {
   tagName: string;
   margin?: string;
   type: 'TEXT' | 'MEDIA' | 'SELECT' | 'PAIN_HSTRY' | 'CONDITION' | 'PAIN_INTV';
+  isCheckedSpecialQuestions?: checkedSpecialQuestions;
+  setIsCheckedSpecialQuestions?: React.Dispatch<
+    React.SetStateAction<checkedSpecialQuestions>
+  >;
 };
+
 export default function QuestionBox({
   image,
   tagTitle,
@@ -18,6 +30,8 @@ export default function QuestionBox({
   tagName,
   margin,
   type,
+  isCheckedSpecialQuestions,
+  setIsCheckedSpecialQuestions,
 }: QuestionBoxProps) {
   const { questionList, setQuestionList } = useContext(MainContext);
 
@@ -27,6 +41,40 @@ export default function QuestionBox({
         marginRight: margin,
       }}
       onClick={() => {
+        if (type === 'PAIN_HSTRY') {
+          if (isCheckedSpecialQuestions?.isPAIN_HSTRY) {
+            alert('전문 문항은 중복으로 추가할 수 없습니다.');
+            return;
+          } else {
+            setIsCheckedSpecialQuestions &&
+              setIsCheckedSpecialQuestions(prevIsChecked => ({
+                ...prevIsChecked,
+                isPAIN_HSTRY: true,
+              }));
+          }
+        } else if (type === 'CONDITION') {
+          if (isCheckedSpecialQuestions?.isCONDITION) {
+            alert('전문 문항은 중복으로 추가할 수 없습니다.');
+            return;
+          } else {
+            setIsCheckedSpecialQuestions &&
+              setIsCheckedSpecialQuestions(prevIsChecked => ({
+                ...prevIsChecked,
+                isCONDITION: true,
+              }));
+          }
+        } else if (type === 'PAIN_INTV') {
+          if (isCheckedSpecialQuestions?.isPAIN_INTV) {
+            alert('전문 문항은 중복으로 추가할 수 없습니다.');
+            return;
+          } else {
+            setIsCheckedSpecialQuestions &&
+              setIsCheckedSpecialQuestions(prevIsChecked => ({
+                ...prevIsChecked,
+                isPAIN_INTV: true,
+              }));
+          }
+        }
         if (questionList.length === 30) {
           alert('템플릿당 문항수는 30개를 초과할 수 없습니다.');
           return;


### PR DESCRIPTION
## 💡 이슈 번호

close #120 

## 📖 작업 내용

- [X] 템플릿 종류 별 전문 문항 분리
- [X] 템플릿 문항 30개 제한
- [X] 전문 문항 중복 추가 불가
- [X] 선택형 문항 보기 없는 경우, 템플릿 생성 불가
- [X] 선택형 문항 보기 중복 불가

## ✅ PR 포인트

- 우선 전체적으로 validation을 추가하면서 alert 창으로 사용자에게 경고하도록 구현했어요.
- 이후 회의를 통해 디자인이나 방식을 수정할 예정이에요.

## 📸 스크린샷
![image](https://github.com/pie-sfac/5-17-smokedDuck/assets/33304871/85db6320-52dc-4b7f-8220-c9ec87a820ad)
![image](https://github.com/pie-sfac/5-17-smokedDuck/assets/33304871/b6310c18-4ce7-4e6e-8722-76f60cb26cf5)
![image](https://github.com/pie-sfac/5-17-smokedDuck/assets/33304871/e1f409b6-c54a-472c-b4a0-b676eb90c671)
![image](https://github.com/pie-sfac/5-17-smokedDuck/assets/33304871/f5a8424c-e36d-4ba9-be91-ca576c905693)
![image](https://github.com/pie-sfac/5-17-smokedDuck/assets/33304871/0ce4f2da-ea3e-40ca-9ecc-bff419d04ed4)
![image](https://github.com/pie-sfac/5-17-smokedDuck/assets/33304871/d090070c-a749-4483-a4b8-9c028fe51c8d)


