### PR TITLE
feat: 템플릿 편집 항목 삭제 / 순서 조정 및 버그 수정

### DIFF
--- a/src/components/Category/CategoryListContents.tsx
+++ b/src/components/Category/CategoryListContents.tsx
@@ -10,12 +10,6 @@ export type categoryListType = {
   id: number;
   title: string;
 };
-
-export type categoryListType = {
-  id: number;
-  title: string;
-};
-
 type CategoryListContentsProps = {
   addedCategory?: categoryListType[];
   isDeleteMode: boolean;

--- a/src/components/UpdateTemplate/UpdateQuestion/UpdateQuestionBox.tsx
+++ b/src/components/UpdateTemplate/UpdateQuestion/UpdateQuestionBox.tsx
@@ -9,12 +9,7 @@ type QuestionBoxProps = {
   tagName: string;
   margin?: string;
   type: 'TEXT' | 'MEDIA' | 'SELECT' | 'PAIN_HSTRY' | 'CONDITION' | 'PAIN_INTV';
-  totalOrder?: number;
-  questionsListHandler: (
-    type: StringQuestionTypes,
-    tagName: string,
-    totalOrder: number
-  ) => void;
+  questionsListHandler: (type: StringQuestionTypes, tagName: string) => void;
 };
 export default function QuestionBox({
   image,
@@ -23,7 +18,6 @@ export default function QuestionBox({
   tagName,
   margin,
   type,
-  totalOrder,
   questionsListHandler,
 }: QuestionBoxProps) {
   return (
@@ -32,9 +26,7 @@ export default function QuestionBox({
         marginRight: margin,
       }}
       onClick={() => {
-        if (totalOrder) {
-          questionsListHandler(type, tagName, totalOrder);
-        }
+        questionsListHandler(type, tagName);
       }}
     >
       <TagNameContainer>

--- a/src/components/UpdateTemplate/UpdateQuestion/UpdateQuestionContent.tsx
+++ b/src/components/UpdateTemplate/UpdateQuestion/UpdateQuestionContent.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
 type QuestionContentProps = {
   onChange: (
@@ -23,19 +23,23 @@ export default function QuestionContent({
   const [currentTitle, setCurrentTitle] = useState(title);
   const [currentDescription, setCurrentDescription] = useState(description);
 
-  const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newTitle = e.target.value;
-    setCurrentTitle(newTitle);
-    onChange(order, 'title', newTitle);
-  };
+  const handleTitleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const newTitle = e.target.value;
+      setCurrentTitle(newTitle);
+      onChange(order, 'title', newTitle);
+    },
+    [onChange, order]
+  );
 
-  const handleDescriptionChange = (
-    e: React.ChangeEvent<HTMLTextAreaElement>
-  ) => {
-    const newDescription = e.target.value;
-    setCurrentDescription(newDescription);
-    onChange(order, 'description', newDescription);
-  };
+  const handleDescriptionChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      const newDescription = e.target.value;
+      setCurrentDescription(newDescription);
+      onChange(order, 'description', newDescription);
+    },
+    [onChange, order]
+  );
 
   return (
     <QuestionContentContainer>

--- a/src/components/UpdateTemplate/UpdateQuestion/UpdateQuestionContent.tsx
+++ b/src/components/UpdateTemplate/UpdateQuestion/UpdateQuestionContent.tsx
@@ -22,6 +22,21 @@ export default function QuestionContent({
 }: QuestionContentProps) {
   const [currentTitle, setCurrentTitle] = useState(title);
   const [currentDescription, setCurrentDescription] = useState(description);
+
+  const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newTitle = e.target.value;
+    setCurrentTitle(newTitle);
+    onChange(order, 'title', newTitle);
+  };
+
+  const handleDescriptionChange = (
+    e: React.ChangeEvent<HTMLTextAreaElement>
+  ) => {
+    const newDescription = e.target.value;
+    setCurrentDescription(newDescription);
+    onChange(order, 'description', newDescription);
+  };
+
   return (
     <QuestionContentContainer>
       <StyledLabel htmlFor="questionTitle">문항 제목</StyledLabel>
@@ -34,10 +49,7 @@ export default function QuestionContent({
           height: '2.5rem',
           margin: '0.4rem 0 0.4rem 0',
         }}
-        onChange={e => {
-          setCurrentTitle(e.target.value);
-          onChange(order, 'title', e.target.value);
-        }}
+        onChange={handleTitleChange}
         value={currentTitle}
         disabled={isCheckOut}
       />
@@ -50,10 +62,7 @@ export default function QuestionContent({
           height: '4.2rem',
           margin: '0.4rem 0 0.4rem 0',
         }}
-        onChange={e => {
-          setCurrentDescription(e.target.value);
-          onChange(order, 'description', e.target.value);
-        }}
+        onChange={handleDescriptionChange}
         value={currentDescription}
         disabled={isCheckOut}
       />

--- a/src/components/UpdateTemplate/UpdateQuestion/UpdateQuestionFooter.tsx
+++ b/src/components/UpdateTemplate/UpdateQuestion/UpdateQuestionFooter.tsx
@@ -1,6 +1,8 @@
 import { Switch } from '@chakra-ui/react';
 import styled from '@emotion/styled';
 import { useState } from 'react';
+import { RxTrash } from 'react-icons/rx';
+import { VscTriangleDown, VscTriangleUp } from 'react-icons/vsc';
 
 type QuestionFooterProps = {
   order: number;
@@ -9,37 +11,67 @@ type QuestionFooterProps = {
     valueKey: string,
     value: string | string[] | boolean
   ) => void;
+  handleDelete: (order: number, isNew: boolean) => void;
+  handleMove: (order: number, direction: string) => void;
   required?: boolean;
+  isBasic: boolean;
+  isNew: boolean;
 };
 
 export default function QuestionFooter({
   order,
   onChange,
+  handleDelete,
+  handleMove,
   required,
+  isBasic,
+  isNew,
 }: QuestionFooterProps) {
   const [isRequired, setIsRequired] = useState(required ? required : false);
   return (
-    <QuestionFooterContainer>
-      <EssentialContainer>
-        <label htmlFor="essential">필수</label>
-        &nbsp;
-        <Switch
-          id={'essential'}
-          size="sm"
-          onChange={() => {
-            setIsRequired(prevIsRequired => !prevIsRequired);
-            onChange(order, 'required', !isRequired);
-          }}
-          defaultChecked={isRequired ? true : false}
-        />
-      </EssentialContainer>
+    <QuestionFooterContainer
+      style={{
+        justifyContent: isBasic ? 'flex-end' : 'space-between',
+      }}
+    >
+      {!isBasic && (
+        <EssentialGuideContainer>
+          * 필수 응답 항목입니다.
+        </EssentialGuideContainer>
+      )}
+      <BasicElementContainer>
+        {isBasic && (
+          <EssentialContainer>
+            <label htmlFor="essential">필수</label>
+            &nbsp;
+            <Switch
+              id={'essential'}
+              size="sm"
+              onChange={() => {
+                setIsRequired(prevIsRequired => !prevIsRequired);
+                onChange(order, 'required', !isRequired);
+              }}
+              defaultChecked={isRequired ? true : false}
+            />
+          </EssentialContainer>
+        )}
+        <MoveContainer>
+          이동 &nbsp;
+          <VscTriangleDown onClick={() => handleMove(order, 'down')} />
+          &nbsp;
+          <VscTriangleUp onClick={() => handleMove(order, 'up')} />
+        </MoveContainer>
+        <RemoveContainer onClick={() => handleDelete(order, isNew)}>
+          삭제 &nbsp;
+          <RxTrash />
+        </RemoveContainer>
+      </BasicElementContainer>
     </QuestionFooterContainer>
   );
 }
 
 const QuestionFooterContainer = styled('div')`
   display: flex;
-  justify-content: flex-end;
   align-items: center;
   font-size: 0.8rem;
 `;
@@ -49,4 +81,29 @@ const EssentialContainer = styled('div')`
   justify-content: center;
   align-items: center;
   margin-right: 1rem;
+`;
+
+const EssentialGuideContainer = styled('div')`
+  color: #1fb881;
+  margin-top: 0.8rem;
+`;
+
+const BasicElementContainer = styled('div')`
+  display: flex;
+  margin-top: 0.8rem;
+`;
+
+const MoveContainer = styled('div')`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-right: 1rem;
+  cursot: pointer;
+`;
+
+const RemoveContainer = styled('div')`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursot: pointer;
 `;

--- a/src/components/UpdateTemplate/UpdateQuestion/index.tsx
+++ b/src/components/UpdateTemplate/UpdateQuestion/index.tsx
@@ -12,6 +12,8 @@ interface QuestionProps {
     valueKey: string,
     value: string | string[] | boolean
   ) => void;
+  handleDelete?: (order: number, isNew: boolean) => void;
+  handleMove?: (order: number, direction: string) => void;
   question: Questions;
   isCheckOut?: boolean;
 }
@@ -19,6 +21,8 @@ interface QuestionProps {
 export default function UpdateQuestion({
   question,
   onChange,
+  handleDelete,
+  handleMove,
   isCheckOut,
 }: QuestionProps) {
   const isBasic = ['TEXT', 'MEDIA', 'SELECT'].includes(question.type);
@@ -60,13 +64,17 @@ export default function UpdateQuestion({
           onChange={onChange!}
         />
       )}
-      {isCheckOut ? (
+      {isCheckOut || !handleDelete || !handleMove ? (
         <></>
       ) : (
         <UpdateQuestionFooter
           order={question.order}
           onChange={onChange!}
           required={question.required}
+          isBasic={isBasic}
+          isNew={question.tagName ? true : false}
+          handleMove={handleMove}
+          handleDelete={handleDelete}
         />
       )}
     </QuestionContainer>

--- a/src/components/UpdateTemplate/UpdateTemplateContent.tsx
+++ b/src/components/UpdateTemplate/UpdateTemplateContent.tsx
@@ -13,11 +13,12 @@ type TemplateContentProps = {
   >;
   totalList: Questions[];
   id: number;
-  questionsListHandler: (
-    type: StringQuestionTypes,
-    tagName: string,
-    totalOrder: number
-  ) => void;
+  caption: {
+    isduplicate: boolean;
+    isMaximun: boolean;
+    errorMessage: string;
+  };
+  questionsListHandler: (type: StringQuestionTypes, tagName: string) => void;
   newQuestionContentHandler: (
     order: number,
     valueKey: string,
@@ -41,16 +42,12 @@ export default function UpdateTemplateContent({
   id,
   handleDelete,
   handleMove,
+  caption,
 }: TemplateContentProps) {
   const { recordDetailData } = useRecordDetail(id);
   if (!recordDetailData) {
     return <Loading />;
   }
-  const totalOrder =
-    recordDetailData.questions.length !== 0
-      ? recordDetailData.questions[recordDetailData.questions.length - 1].order
-      : 1;
-
   return (
     <div>
       <>
@@ -62,8 +59,9 @@ export default function UpdateTemplateContent({
           setCurrTemplateSubHeader={setCurrTemplateSubHeader}
         />
         <UpdateTemplateQuestionSelections
-          totalOrder={totalOrder}
           questionsListHandler={questionsListHandler}
+          category={recordDetailData.category}
+          caption={caption}
         />
         <UpdateTemplateSelectedQuestionContainer
           newQuestionContentHandler={newQuestionContentHandler}

--- a/src/components/UpdateTemplate/UpdateTemplateContent.tsx
+++ b/src/components/UpdateTemplate/UpdateTemplateContent.tsx
@@ -11,8 +11,7 @@ type TemplateContentProps = {
   setCurrTemplateSubHeader: Dispatch<
     SetStateAction<{ title: string; description: string }>
   >;
-  updateQuestions: Questions[];
-  addQuestions: Questions[];
+  totalList: Questions[];
   id: number;
   questionsListHandler: (
     type: StringQuestionTypes,
@@ -29,6 +28,8 @@ type TemplateContentProps = {
     valueKey: string,
     value: string | string[] | boolean
   ) => void;
+  handleDelete: (order: number, isNew: boolean) => void;
+  handleMove: (order: number, direction: string) => void;
 };
 
 export default function UpdateTemplateContent({
@@ -36,9 +37,10 @@ export default function UpdateTemplateContent({
   questionsListHandler,
   newQuestionContentHandler,
   existQuestionContentHandler,
-  updateQuestions,
-  addQuestions,
+  totalList,
   id,
+  handleDelete,
+  handleMove,
 }: TemplateContentProps) {
   const { recordDetailData } = useRecordDetail(id);
   if (!recordDetailData) {
@@ -66,7 +68,9 @@ export default function UpdateTemplateContent({
         <UpdateTemplateSelectedQuestionContainer
           newQuestionContentHandler={newQuestionContentHandler}
           existQuestionContentHandler={existQuestionContentHandler}
-          totalQuestions={[...updateQuestions, ...addQuestions]}
+          totalQuestions={totalList}
+          handleDelete={handleDelete}
+          handleMove={handleMove}
           id={id}
         />
       </>

--- a/src/components/UpdateTemplate/UpdateTemplateFooter.tsx
+++ b/src/components/UpdateTemplate/UpdateTemplateFooter.tsx
@@ -1,22 +1,22 @@
 import { Button } from '@chakra-ui/react';
 import styled from '@emotion/styled';
 
-import { Questions } from '@/types/question.interface';
-import { recordQuestionsType } from '@/types/recordDetail.interface';
-
 type UpdateTemplateFooterProps = {
   handleClickedSaveButton: (templateId?: number) => Promise<void>;
   id: number;
-  updateQuestions: recordQuestionsType[];
-  addQuestions: Questions[];
+  validation: { isValidate: boolean; errorMessage: string };
 };
 
 export default function UpdateTemplateFooter({
   handleClickedSaveButton,
   id,
+  validation,
 }: UpdateTemplateFooterProps) {
   return (
     <FooterContainer>
+      {!validation.isValidate && (
+        <ValidateCaption>{validation.errorMessage}</ValidateCaption>
+      )}
       <Button
         fontSize={'1rem'}
         _active={{
@@ -33,8 +33,14 @@ export default function UpdateTemplateFooter({
 }
 
 const FooterContainer = styled('div')`
-  height: 3.5rem;
   margin: 0.2rem 2rem 0.2rem 2rem;
   display: flex;
   justify-content: flex-end;
+  align-items: center;
+`;
+
+const ValidateCaption = styled.span`
+  font-size: 13px;
+  color: red;
+  margin-right: 1rem;
 `;

--- a/src/components/UpdateTemplate/UpdateTemplateQuestionSelections.tsx
+++ b/src/components/UpdateTemplate/UpdateTemplateQuestionSelections.tsx
@@ -160,7 +160,6 @@ const QeustionsContainer = styled('div')`
 const QuestionBoxContainer = styled('div')`
   display: flex;
   margin: 0 2rem 0 2rem;
-  justify-content: space-between;
 `;
 
 const Caption = styled.span`

--- a/src/components/UpdateTemplate/UpdateTemplateQuestionSelections.tsx
+++ b/src/components/UpdateTemplate/UpdateTemplateQuestionSelections.tsx
@@ -12,22 +12,31 @@ import UpdateQuestionBox from '@/components/UpdateTemplate/UpdateQuestion/Update
 import { StringQuestionTypes } from '@/types/question.interface';
 
 type UpdateTemplateQuestionSelectionsProps = {
-  totalOrder: number;
-  questionsListHandler: (
-    type: StringQuestionTypes,
-    tagName: string,
-    totalOrder: number
-  ) => void;
+  category: string;
+  caption: {
+    isduplicate: boolean;
+    isMaximun: boolean;
+    errorMessage: string;
+  };
+  questionsListHandler: (type: StringQuestionTypes, tagName: string) => void;
 };
 
 export default function UpdateTemplateQuestionSelections({
-  totalOrder,
   questionsListHandler,
+  category,
+  caption,
 }: UpdateTemplateQuestionSelectionsProps) {
+  const renderCaption = () => {
+    if (caption.isduplicate || caption.isMaximun) {
+      return <Caption>{caption.errorMessage}</Caption>;
+    }
+    return null;
+  };
   const [selectedQuestion, setSelectedQuestion] = useState('basic');
   return (
     <EntireQuestionContainer>
       <QeustionsContainer>
+        {renderCaption()}
         <Box
           as="button"
           padding={1}
@@ -75,7 +84,6 @@ export default function UpdateTemplateQuestionSelections({
             margin={'0.4rem'}
             type={'TEXT'}
             questionsListHandler={questionsListHandler}
-            totalOrder={totalOrder}
           />
           <UpdateQuestionBox
             image={Media}
@@ -85,7 +93,6 @@ export default function UpdateTemplateQuestionSelections({
             margin={'0.4rem'}
             type={'MEDIA'}
             questionsListHandler={questionsListHandler}
-            totalOrder={totalOrder}
           />
           <UpdateQuestionBox
             image={Selections}
@@ -94,43 +101,45 @@ export default function UpdateTemplateQuestionSelections({
             tagName={'기본'}
             type={'SELECT'}
             questionsListHandler={questionsListHandler}
-            totalOrder={totalOrder}
           />
         </QuestionBoxContainer>
       )}
       {selectedQuestion === 'specialty' && (
         <QuestionBoxContainer>
-          <UpdateQuestionBox
-            image={Pain}
-            tagTitle={'통증 정도'}
-            description={'회원의 통증 정도를 선택하는 문항입니다.'}
-            tagName={'전문'}
-            margin={'0.4rem'}
-            type={'PAIN_HSTRY'}
-            questionsListHandler={questionsListHandler}
-            totalOrder={totalOrder}
-          />
-          <UpdateQuestionBox
-            image={Condition}
-            tagTitle={'오늘의 컨디션'}
-            description={'회원의 컨디션 정도를 선택하는 문항입니다.'}
-            tagName={'전문'}
-            margin={'0.4rem'}
-            type={'CONDITION'}
-            questionsListHandler={questionsListHandler}
-            totalOrder={totalOrder}
-          />
-          <UpdateQuestionBox
-            image={PainQuestion}
-            tagTitle={'통증 문진'}
-            description={
-              '통증 부위, 유형, 정도, 빈도, 기간을 작성할 수 있는 문항입니다.'
-            }
-            tagName={'전문'}
-            type={'PAIN_INTV'}
-            questionsListHandler={questionsListHandler}
-            totalOrder={totalOrder}
-          />
+          {category === 'INTERVIEW' && (
+            <UpdateQuestionBox
+              image={PainQuestion}
+              tagTitle={'통증 문진'}
+              description={
+                '통증 부위, 유형, 정도, 빈도, 기간을 작성할 수 있는 문항입니다.'
+              }
+              tagName={'전문'}
+              type={'PAIN_INTV'}
+              questionsListHandler={questionsListHandler}
+            />
+          )}
+          {category === 'TREATMENT' && (
+            <>
+              <UpdateQuestionBox
+                image={Pain}
+                tagTitle={'통증 정도'}
+                description={'회원의 통증 정도를 선택하는 문항입니다.'}
+                tagName={'전문'}
+                margin={'0.4rem'}
+                type={'PAIN_HSTRY'}
+                questionsListHandler={questionsListHandler}
+              />
+              <UpdateQuestionBox
+                image={Condition}
+                tagTitle={'오늘의 컨디션'}
+                description={'회원의 컨디션 정도를 선택하는 문항입니다.'}
+                tagName={'전문'}
+                margin={'0.4rem'}
+                type={'CONDITION'}
+                questionsListHandler={questionsListHandler}
+              />
+            </>
+          )}
         </QuestionBoxContainer>
       )}
     </EntireQuestionContainer>
@@ -145,10 +154,17 @@ const QeustionsContainer = styled('div')`
   display: flex;
   justify-content: flex-end;
   margin: 0 2rem 1rem 2rem;
+  align-items: center;
 `;
 
 const QuestionBoxContainer = styled('div')`
   display: flex;
   margin: 0 2rem 0 2rem;
   justify-content: space-between;
+`;
+
+const Caption = styled.span`
+  font-size: 12px;
+  color: red;
+  margin-right: 1rem;
 `;

--- a/src/components/UpdateTemplate/UpdateTemplateSelectedQuestionContainer.tsx
+++ b/src/components/UpdateTemplate/UpdateTemplateSelectedQuestionContainer.tsx
@@ -69,9 +69,9 @@ export default function UpdateTemplateSelectedQuestionContainer({
           문항이 없습니다.
         </EmptyQuestionContainer>
       ) : (
-        questionList.map((question, idx) => (
+        questionList.map(question => (
           <UpdateQuestion
-            key={question.order + idx * Math.random()}
+            key={question.id}
             question={question}
             onChange={
               question.tagName

--- a/src/components/UpdateTemplate/UpdateTemplateSelectedQuestionContainer.tsx
+++ b/src/components/UpdateTemplate/UpdateTemplateSelectedQuestionContainer.tsx
@@ -18,6 +18,8 @@ type UpdateTemplateSelectedQuestionContainerProps = {
     valueKey: string,
     value: string | string[] | boolean
   ) => void;
+  handleDelete: (order: number, isNew: boolean) => void;
+  handleMove: (order: number, direction: string) => void;
   totalQuestions: Questions[];
   id: number;
 };
@@ -25,6 +27,8 @@ type UpdateTemplateSelectedQuestionContainerProps = {
 export default function UpdateTemplateSelectedQuestionContainer({
   newQuestionContentHandler,
   existQuestionContentHandler,
+  handleDelete,
+  handleMove,
   totalQuestions,
   id,
 }: UpdateTemplateSelectedQuestionContainerProps) {
@@ -74,6 +78,8 @@ export default function UpdateTemplateSelectedQuestionContainer({
                 ? newQuestionContentHandler
                 : existQuestionContentHandler
             }
+            handleDelete={handleDelete}
+            handleMove={handleMove}
           />
         ))
       )}

--- a/src/components/UpdateTemplate/UpdateTemplateSelectedQuestionContainer.tsx
+++ b/src/components/UpdateTemplate/UpdateTemplateSelectedQuestionContainer.tsx
@@ -69,9 +69,9 @@ export default function UpdateTemplateSelectedQuestionContainer({
           문항이 없습니다.
         </EmptyQuestionContainer>
       ) : (
-        questionList.map(question => (
+        questionList.map((question, idx) => (
           <UpdateQuestion
-            key={question.order}
+            key={question.order + idx * Math.random()}
             question={question}
             onChange={
               question.tagName

--- a/src/components/UpdateTemplate/index.tsx
+++ b/src/components/UpdateTemplate/index.tsx
@@ -42,7 +42,7 @@ export default function UpdateTemplate({
     errorMessage: '',
   });
   //벨리데이션 검증
-  const checkValidation = () => {
+  const checkValidation = useCallback(() => {
     let isValid = true;
     let errorMessage = '';
 
@@ -78,21 +78,21 @@ export default function UpdateTemplate({
     });
 
     return isValid;
-  };
+  }, [currTemplateSubHeader.title.length, totalList]);
 
-  const syncOrder = (
-    targetList: Questions[],
-    correctOrderList: Questions[]
-  ) => {
-    return targetList.map(listItem => {
-      const newOrder = correctOrderList.find(item => item.id === listItem.id)
-        ?.order;
-      return {
-        ...listItem,
-        order: newOrder ? newOrder : 0,
-      };
-    });
-  };
+  const syncOrder = useCallback(
+    (targetList: Questions[], correctOrderList: Questions[]) => {
+      return targetList.map(listItem => {
+        const newOrder = correctOrderList.find(item => item.id === listItem.id)
+          ?.order;
+        return {
+          ...listItem,
+          order: newOrder ? newOrder : 0,
+        };
+      });
+    },
+    []
+  );
 
   //저장버튼 누를때 PUT 요청
   const handleClickedSaveButton = async (templateId?: number) => {
@@ -125,61 +125,68 @@ export default function UpdateTemplate({
   };
 
   //문항 박스들 클릭하면 questionList에 담는함수
-  const questionsListHandler = (type: StringQuestionTypes, tagName: string) => {
-    setCaption({
-      isMaximun: false,
-      isduplicate: false,
-      errorMessage: '',
-    });
+  const questionsListHandler = useCallback(
+    (type: StringQuestionTypes, tagName: string) => {
+      setCaption({
+        isMaximun: false,
+        isduplicate: false,
+        errorMessage: '',
+      });
 
-    const newQuestionId =
-      updateQuestions.length === 0
-        ? addQuestions.length === 0
-          ? 1
-          : addQuestions[addQuestions.length - 1].id + 1
-        : addQuestions.length === 0
-        ? updateQuestions[updateQuestions.length - 1].id + 1
-        : addQuestions[addQuestions.length - 1].id + 1;
+      const newQuestionId =
+        updateQuestions.length === 0
+          ? addQuestions.length === 0
+            ? 1
+            : addQuestions[addQuestions.length - 1].id + 1
+          : addQuestions.length === 0
+          ? updateQuestions[updateQuestions.length - 1].id + 1
+          : addQuestions[addQuestions.length - 1].id + 1;
 
-    const newOrder =
-      totalList.length === 0 ? 1 : totalList[totalList.length - 1].order + 1;
+      const newOrder =
+        totalList.length === 0 ? 1 : totalList[totalList.length - 1].order + 1;
 
-    //전문문항 중복되는지 확인
-    if (type === 'PAIN_HSTRY' || type === 'PAIN_INTV' || type === 'CONDITION') {
-      if (totalList.find(listItem => listItem.type === type)) {
+      //전문문항 중복되는지 확인
+      if (
+        type === 'PAIN_HSTRY' ||
+        type === 'PAIN_INTV' ||
+        type === 'CONDITION'
+      ) {
+        if (totalList.find(listItem => listItem.type === type)) {
+          setCaption({
+            ...caption,
+            isduplicate: true,
+            errorMessage: '전문 문항은 중복으로 추가할 수 없습니다.',
+          });
+          return;
+        }
+      }
+      if (totalList.length > 29) {
         setCaption({
           ...caption,
-          isduplicate: true,
-          errorMessage: '전문 문항은 중복으로 추가할 수 없습니다.',
+          isMaximun: true,
+          errorMessage: '템플릿당 문항수는 30개를 초과할 수 없습니다.',
         });
         return;
       }
-    }
-    if (totalList.length > 29) {
-      setCaption({
-        ...caption,
-        isMaximun: true,
-        errorMessage: '템플릿당 문항수는 30개를 초과할 수 없습니다.',
-      });
-      return;
-    }
 
-    const newQuestion = {
-      id: newQuestionId,
-      type,
-      order: newOrder,
-      required: false,
-      title: '',
-      tagName,
-      description: '',
-      paragraph: false,
-      options: [],
-      allowMultiple: false,
-      addOtherOption: false,
-    };
-    setAddQuestions([...addQuestions, newQuestion]);
-    setTotalList([...totalList, newQuestion]);
-  };
+      const newQuestion = {
+        id: newQuestionId,
+        type,
+        order: newOrder,
+        required: false,
+        title: '',
+        tagName,
+        description: '',
+        paragraph: false,
+        options: [],
+        allowMultiple: false,
+        addOtherOption: false,
+      };
+      setAddQuestions([...addQuestions, newQuestion]);
+      setTotalList([...totalList, newQuestion]);
+    },
+    [addQuestions, caption, totalList, updateQuestions]
+  );
 
   //기존의 항목들 수정하는 함수
   const existQuestionContentHandler = useCallback(
@@ -288,7 +295,7 @@ export default function UpdateTemplate({
       }
     },
 
-    [addQuestions, totalList, updateQuestions]
+    [addQuestions, syncOrder, totalList, updateQuestions]
   );
   return (
     <>

--- a/src/components/UpdateTemplate/index.tsx
+++ b/src/components/UpdateTemplate/index.tsx
@@ -26,20 +26,38 @@ export default function UpdateTemplate({
       ? recordDetailData.description
       : '',
   });
+  const [deleteIds, setDeleteIds] = useState<number[]>([]);
   const [updateQuestions, setUpdateQuestions] = useState<Questions[]>(
     recordDetailData.questions
   );
   const [addQuestions, setAddQuestions] = useState<Questions[]>([]);
+  const [totalList, setTotalList] = useState<Questions[]>(updateQuestions);
 
   //저장버튼 누를때 PUT 요청
   const handleClickedSaveButton = async (templateId?: number) => {
+    //total리스트의 order값과 동기화
+    const updateList = updateQuestions.map(listItem => {
+      const newOrder = totalList.find(item => item.id === listItem.id)?.order;
+      return {
+        ...listItem,
+        order: newOrder ? newOrder : 0,
+      };
+    });
+
+    const addList = addQuestions.map(listItem => {
+      const newOrder = totalList.find(item => item.id === listItem.id)?.order;
+      return {
+        ...listItem,
+        order: newOrder ? newOrder : 0,
+      };
+    });
     const updatedTemplateContent: UpdateTemplateType = {
       title: currTemplateSubHeader.title,
       description: currTemplateSubHeader.description,
-      updateQuestions: updateQuestions ? updateQuestions : [],
-      addQuestions,
+      updateQuestions: updateList,
+      addQuestions: addList,
+      deleteIds,
     };
-
     if (templateId) {
       await updateTemplateAPI(templateId, updatedTemplateContent);
     }
@@ -62,26 +80,35 @@ export default function UpdateTemplate({
     tagName: string,
     totalOrder: number
   ) => {
-    setAddQuestions([
-      ...addQuestions,
-      {
-        id: 0,
-        type,
-        order:
-          addQuestions.length === 0
-            ? totalOrder + 1
-            : addQuestions[addQuestions.length - 1].order + 1,
-        required: false,
-        title: '',
-        tagName,
-        description: '',
-        paragraph: false,
-        options: [],
-        allowMultiple: false,
-        addOtherOption: false,
-      },
-    ]);
+    const newQuestionId =
+      updateQuestions.length === 0
+        ? addQuestions.length === 0
+          ? 1
+          : addQuestions[addQuestions.length - 1].id + 1
+        : addQuestions.length === 0
+        ? updateQuestions[updateQuestions.length - 1].id + 1
+        : addQuestions[addQuestions.length - 1].id + 1;
+
+    const newQuestion = {
+      id: newQuestionId,
+      type,
+      order:
+        addQuestions.length === 0
+          ? totalOrder
+          : addQuestions[addQuestions.length - 1].order + 1,
+      required: false,
+      title: '',
+      tagName,
+      description: '',
+      paragraph: false,
+      options: [],
+      allowMultiple: false,
+      addOtherOption: false,
+    };
+    setAddQuestions([...addQuestions, newQuestion]);
+    setTotalList([...totalList, newQuestion]);
   };
+
   //기존의 항목들 수정하는 함수
   const existQuestionContentHandler = useCallback(
     (order: number, valueKey: string, value: string | string[] | boolean) => {
@@ -109,6 +136,73 @@ export default function UpdateTemplate({
     [addQuestions, setAddQuestions]
   );
 
+  //항목 삭제
+  const questionDeleteHandler = useCallback(
+    (order: number, isNew: boolean) => {
+      const targetQuestion = totalList.find(item => item.order === order);
+      if (!isNew && targetQuestion) {
+        setDeleteIds([...deleteIds, targetQuestion.id]);
+        setUpdateQuestions(
+          updateQuestions.filter(item => item.order !== order)
+        );
+      } else if (targetQuestion) {
+        setAddQuestions(addQuestions.filter(item => item.order !== order));
+      }
+
+      setTotalList(
+        totalList
+          .filter(item => item.order !== order)
+          .sort((a, b) => a.order - b.order)
+          .map((item, index) => {
+            return { ...item, order: index + 1 };
+          })
+      );
+    },
+    [addQuestions, deleteIds, totalList, updateQuestions]
+  );
+
+  //항목 이동
+  const questionMoveHandler = useCallback(
+    (targetOrder: number, direction: string) => {
+      if (direction === 'up' && targetOrder === 1) {
+        alert('첫번째 문항입니다.');
+        return;
+      } else if (
+        direction === 'down' &&
+        targetOrder === totalList[totalList.length - 1].order
+      ) {
+        alert('마지막 문항입니다.');
+        return;
+      }
+
+      if (direction === 'up') {
+        const newList = totalList.map(item => {
+          if (item.order === targetOrder - 1)
+            return { ...item, order: item.order + 1 };
+
+          if (item.order === targetOrder)
+            return { ...item, order: item.order - 1 };
+
+          return item;
+        });
+
+        setTotalList(newList.sort((a, b) => a.order - b.order));
+      }
+      if (direction === 'down') {
+        const newList = totalList.map(item => {
+          if (item.order === targetOrder + 1)
+            return { ...item, order: item.order - 1 };
+
+          if (item.order === targetOrder)
+            return { ...item, order: item.order + 1 };
+
+          return item;
+        });
+        setTotalList(newList.sort((a, b) => a.order - b.order));
+      }
+    },
+    [totalList]
+  );
   return (
     <>
       <UpdateTemplateTitle id={id} isEditing={true} />
@@ -118,8 +212,9 @@ export default function UpdateTemplate({
         questionsListHandler={questionsListHandler}
         newQuestionContentHandler={newQuestionContentHandler}
         existQuestionContentHandler={existQuestionContentHandler}
-        updateQuestions={updateQuestions}
-        addQuestions={addQuestions}
+        handleDelete={questionDeleteHandler}
+        handleMove={questionMoveHandler}
+        totalList={totalList}
       />
       <UpdateTemplateFooter
         handleClickedSaveButton={handleClickedSaveButton}

--- a/src/components/UpdateTemplate/index.tsx
+++ b/src/components/UpdateTemplate/index.tsx
@@ -80,26 +80,27 @@ export default function UpdateTemplate({
     return isValid;
   };
 
+  const syncOrder = (
+    targetList: Questions[],
+    correctOrderList: Questions[]
+  ) => {
+    return targetList.map(listItem => {
+      const newOrder = correctOrderList.find(item => item.id === listItem.id)
+        ?.order;
+      return {
+        ...listItem,
+        order: newOrder ? newOrder : 0,
+      };
+    });
+  };
+
   //저장버튼 누를때 PUT 요청
   const handleClickedSaveButton = async (templateId?: number) => {
     const isRight = checkValidation();
     if (!isRight) return;
     //total리스트의 order값과 동기화
-    const updateList = updateQuestions.map(listItem => {
-      const newOrder = totalList.find(item => item.id === listItem.id)?.order;
-      return {
-        ...listItem,
-        order: newOrder ? newOrder : 0,
-      };
-    });
-
-    const addList = addQuestions.map(listItem => {
-      const newOrder = totalList.find(item => item.id === listItem.id)?.order;
-      return {
-        ...listItem,
-        order: newOrder ? newOrder : 0,
-      };
-    });
+    const updateList = syncOrder(updateQuestions, totalList);
+    const addList = syncOrder(addQuestions, totalList);
     const updatedTemplateContent: UpdateTemplateType = {
       title: currTemplateSubHeader.title,
       description: currTemplateSubHeader.description,
@@ -187,7 +188,11 @@ export default function UpdateTemplate({
         question.order === order ? { ...question, [valueKey]: value } : question
       );
       setUpdateQuestions(currentUpdatedQuestion);
-      setTotalList([...currentUpdatedQuestion, ...addQuestions]);
+      setTotalList(
+        [...currentUpdatedQuestion, ...addQuestions].sort(
+          (a, b) => a.order - b.order
+        )
+      );
     },
 
     [addQuestions, updateQuestions]
@@ -203,7 +208,11 @@ export default function UpdateTemplate({
             : question
         );
         setAddQuestions(currentUpdatedQuestion);
-        setTotalList([...updateQuestions, ...currentUpdatedQuestion]);
+        setTotalList(
+          [...updateQuestions, ...currentUpdatedQuestion].sort(
+            (a, b) => a.order - b.order
+          )
+        );
       }
     },
     [addQuestions, updateQuestions]
@@ -260,6 +269,8 @@ export default function UpdateTemplate({
         });
 
         setTotalList(newList.sort((a, b) => a.order - b.order));
+        setAddQuestions(syncOrder(addQuestions, newList));
+        setUpdateQuestions(syncOrder(updateQuestions, newList));
       }
       if (direction === 'down') {
         const newList = totalList.map(item => {
@@ -272,9 +283,12 @@ export default function UpdateTemplate({
           return item;
         });
         setTotalList(newList.sort((a, b) => a.order - b.order));
+        setAddQuestions(syncOrder(addQuestions, newList));
+        setUpdateQuestions(syncOrder(updateQuestions, newList));
       }
     },
-    [totalList]
+
+    [addQuestions, totalList, updateQuestions]
   );
   return (
     <>

--- a/src/components/UpdateTemplate/index.tsx
+++ b/src/components/UpdateTemplate/index.tsx
@@ -33,8 +33,39 @@ export default function UpdateTemplate({
   const [addQuestions, setAddQuestions] = useState<Questions[]>([]);
   const [totalList, setTotalList] = useState<Questions[]>(updateQuestions);
 
+  //벨리데이션 검증
+  const checkValidation = () => {
+    if (currTemplateSubHeader.title.length === 0) {
+      alert('템플릿 제목을 입력해주세요.');
+      return false;
+    }
+
+    totalList.forEach(listItem => {
+      if (
+        (listItem.type === 'TEXT' || listItem.type === 'MEDIA') &&
+        listItem.title.length === 0
+      ) {
+        alert(`${listItem.type} 문항의 제목을 입력해주세요.`);
+        return false;
+      }
+      if (listItem.type === 'SELECT' && listItem.options?.length === 0) {
+        alert('선택형 문항의 보기가 존재하지 않습니다.');
+        return false;
+      } else if (listItem.type === 'SELECT' && listItem.options?.length !== 0) {
+        const set = new Set(listItem.options);
+        if (set.size !== listItem.options?.length) {
+          alert(
+            '작성하신 선택형 문항의 보기 중 중복값이 존재합니다. 중복을 수정해주세요.'
+          );
+          return false;
+        }
+      }
+    });
+  };
+
   //저장버튼 누를때 PUT 요청
   const handleClickedSaveButton = async (templateId?: number) => {
+    if (!checkValidation) return;
     //total리스트의 order값과 동기화
     const updateList = updateQuestions.map(listItem => {
       const newOrder = totalList.find(item => item.id === listItem.id)?.order;

--- a/src/components/UpdateTemplate/index.tsx
+++ b/src/components/UpdateTemplate/index.tsx
@@ -141,11 +141,7 @@ export default function UpdateTemplate({
         : addQuestions[addQuestions.length - 1].id + 1;
 
     const newOrder =
-      addQuestions.length === 0
-        ? updateQuestions.length === 0
-          ? 1
-          : updateQuestions[updateQuestions.length - 1].order + 1
-        : addQuestions[addQuestions.length - 1].order + 1;
+      totalList.length === 0 ? 1 : totalList[totalList.length - 1].order + 1;
 
     //전문문항 중복되는지 확인
     if (type === 'PAIN_HSTRY' || type === 'PAIN_INTV' || type === 'CONDITION') {

--- a/src/components/record/RecordContents.tsx
+++ b/src/components/record/RecordContents.tsx
@@ -9,21 +9,19 @@ import { MainContext } from '@/store';
 
 export default function RecordContents() {
   const { selectedRecordCardId } = useContext(MainContext);
-  const { recordDetailData, isLoading } = useRecordDetail(selectedRecordCardId);
+  const { recordQuestions, isLoading } = useRecordDetail(selectedRecordCardId);
 
-  if (isLoading || !recordDetailData) {
+  if (isLoading || !recordQuestions) {
     return <Loading />;
   }
   return (
     <ContentContainer
       style={{
         backgroundColor:
-          recordDetailData.questions.length !== 0
-            ? 'rgba(235, 241, 255, 0.26)'
-            : 'none',
+          recordQuestions.length !== 0 ? 'rgba(235, 241, 255, 0.26)' : 'none',
       }}
     >
-      {recordDetailData.questions.length === 0 ? (
+      {recordQuestions.length === 0 ? (
         <EmptyQuestionContainer>
           <img
             src={EmptyQuestion}
@@ -33,7 +31,7 @@ export default function RecordContents() {
           문항이 없습니다.
         </EmptyQuestionContainer>
       ) : (
-        recordDetailData.questions.map(question => (
+        recordQuestions.map(question => (
           <UpdateQuestion
             question={question}
             key={Math.random() * 100}

--- a/src/hooks/useRecordDetail.tsx
+++ b/src/hooks/useRecordDetail.tsx
@@ -15,7 +15,9 @@ export default function useRecordDetail(id: number) {
 
   return {
     recordDetailData: recordDetailData,
-    recordQuestions: recordDetailData?.questions,
+    recordQuestions: recordDetailData?.questions.sort(
+      (a, b) => a.order - b.order
+    ),
     mutate: mutate,
     isLoading: !error && !recordDetailData,
   };

--- a/src/types/template.interface.ts
+++ b/src/types/template.interface.ts
@@ -19,6 +19,7 @@ export interface UpdateTemplateType {
   description: string | undefined;
   updateQuestions: recordQuestionsType[] | [];
   addQuestions: Questions[];
+  deleteIds: number[];
 }
 
 export interface UpdateTemplateResponse {


### PR DESCRIPTION
## 💡 이슈 번호

close #130 

## 📖 작업 내용

- [x] 템플릿 편집 화면에서 항목 삭제
- [x] 템플릿 편집 화면에서 항목 이동
- [x] 기존의 템플릿 항목이 하나도 없을경우 order가 2로 시작하는 버그 해결
- [x] validate 확인 및 경고문 렌더링

## ✅ PR 포인트

- 봐야하는 부분
경고문 위치 및 작동 잘되는지 확인 부탁드립니다.
Record와 updateTemplate외에 다른 컴포넌트 변경한건 실행 오류 해결한 부분입니다.


## 📸 스크린샷

https://github.com/pie-sfac/5-17-smokedDuck/assets/104823768/d72c40b9-63ac-4ef2-b2f3-9a98aea888a2

