### PR TITLE
refactor: 공통 type 분리 및 컨벤션 일괄 적용

### DIFF
--- a/src/apis/Login.ts
+++ b/src/apis/Login.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-import { tokenType } from '@/types/token.interface';
+import { token } from '@/types/token.interface';
 const refreshAxios = axios.create({
   baseURL: 'http://223.130.161.221/api/v1',
   headers: {
@@ -20,7 +20,7 @@ export async function requestLogin(username: string, password: string) {
   };
 
   try {
-    const response = await axios.post<tokenType>(`/admins/login`, '', {
+    const response = await axios.post<token>(`/admins/login`, '', {
       headers,
       withCredentials: true,
     });
@@ -36,13 +36,13 @@ export async function requestLogin(username: string, password: string) {
 }
 
 export function onSlientRefresh() {
-  refreshAxios.post<tokenType>('/tokens').then(res => {
+  refreshAxios.post<token>('/tokens').then(res => {
     onLoginSuccess(res);
     window.localStorage.setItem('refreshToken', res.data.refreshToken);
   });
 }
 
-export function onLoginSuccess(res: { data: tokenType }) {
+export function onLoginSuccess(res: { data: token }) {
   const { accessToken, refreshToken } = res.data;
 
   axios.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;

--- a/src/apis/Template.ts
+++ b/src/apis/Template.ts
@@ -1,18 +1,11 @@
 import axios, { AxiosResponse } from 'axios';
 
-import { Questions } from '@/types/question.interface';
 import {
   CreateTemplateResponse,
+  NewTemplateContent,
   UpdateTemplateResponse,
   UpdateTemplateType,
 } from '@/types/template.interface';
-
-type NewTemplateContent = {
-  questions: Questions[];
-  category?: '' | 'INTERVIEW' | 'TREATMENT' | undefined;
-  title?: string | undefined;
-  description?: string | undefined;
-};
 
 const TEMPLATE_URL = '/record-templates';
 

--- a/src/components/Category/CategoryListContents.tsx
+++ b/src/components/Category/CategoryListContents.tsx
@@ -6,18 +6,13 @@ import useCategory from '@/utils/categoryData';
 
 import DeleteModal from '../Common/DeleteModal';
 
-export type categoryListType = {
-  id: number;
-  title: string;
-};
-
-export type categoryListType = {
+export type categoryList = {
   id: number;
   title: string;
 };
 
 type CategoryListContentsProps = {
-  addedCategory?: categoryListType[];
+  addedCategory?: categoryList[];
   isDeleteMode: boolean;
   setIsDeleteMode: React.Dispatch<React.SetStateAction<boolean>>;
   handleUpdateCategory: (categoryId: number, updateText: string) => void;

--- a/src/components/Category/CategoryListContents.tsx
+++ b/src/components/Category/CategoryListContents.tsx
@@ -6,12 +6,13 @@ import useCategory from '@/utils/categoryData';
 
 import DeleteModal from '../Common/DeleteModal';
 
-export type categoryListType = {
+export type categoryList = {
   id: number;
   title: string;
 };
+
 type CategoryListContentsProps = {
-  addedCategory?: categoryListType[];
+  addedCategory?: categoryList[];
   isDeleteMode: boolean;
   setIsDeleteMode: React.Dispatch<React.SetStateAction<boolean>>;
   handleUpdateCategory: (categoryId: number, updateText: string) => void;

--- a/src/components/Category/index.tsx
+++ b/src/components/Category/index.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { createCategory, updateCategory } from '@/apis/Category';
 import { MainContext } from '@/store';
-import { CategoryRequestDTO } from '@/types/category.interface';
+import { CategoryRequest } from '@/types/category.interface';
 import useCategory from '@/utils/categoryData';
 
 import CategoryHeader from './CategoryHeader';
@@ -23,7 +23,7 @@ export default function Category() {
       return;
     }
     try {
-      const newCategoryList: CategoryRequestDTO = {
+      const newCategoryList: CategoryRequest = {
         title: '',
         description: '',
       };
@@ -50,7 +50,7 @@ export default function Category() {
         return data;
       }, false);
 
-      const updatedCategoryData: CategoryRequestDTO = {
+      const updatedCategoryData: CategoryRequest = {
         title: updateText,
         description: '',
       };

--- a/src/components/Link/LinkForm.tsx
+++ b/src/components/Link/LinkForm.tsx
@@ -12,7 +12,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import useSWR from 'swr';
 
 import { getLinkDetails, LINK_URL } from '@/apis/Media';
-import { CategoryResponseDTO } from '@/types/category.interface';
+import { CategoryResponse } from '@/types/category.interface';
 import { FormData } from '@/types/media.interface';
 import useCategory from '@/utils/categoryData';
 import { getLinkUrlInfo } from '@/utils/validations/linkUtils';
@@ -161,7 +161,7 @@ export default function LinkForm({ onSubmit, linkId }: LinkFormProps) {
               setCategory(Number(event.target.value));
             }}
           >
-            {categories?.categories.map((categoryInfo: CategoryResponseDTO) => (
+            {categories?.categories.map((categoryInfo: CategoryResponse) => (
               <option key={categoryInfo.id} value={categoryInfo.id}>
                 {categoryInfo.title}
               </option>

--- a/src/components/Question/index.tsx
+++ b/src/components/Question/index.tsx
@@ -15,7 +15,7 @@ type checkedSpecialQuestions = {
   isPAIN_INTV: boolean;
 };
 
-interface QuestionProps {
+type QuestionProps = {
   onChange: (
     order: number,
     id: string,
@@ -25,7 +25,7 @@ interface QuestionProps {
   setIsCheckedSpecialQuestions: React.Dispatch<
     React.SetStateAction<checkedSpecialQuestions>
   >;
-}
+};
 
 export default function Question({
   onChange,

--- a/src/components/Template/Question/index.tsx
+++ b/src/components/Template/Question/index.tsx
@@ -15,7 +15,7 @@ type checkedSpecialQuestions = {
   isPAIN_INTV: boolean;
 };
 
-interface QuestionProps {
+type QuestionProps = {
   onChange: (
     order: number,
     id: string,
@@ -25,7 +25,7 @@ interface QuestionProps {
   setIsCheckedSpecialQuestions: React.Dispatch<
     React.SetStateAction<checkedSpecialQuestions>
   >;
-}
+};
 
 export default function Question({
   onChange,

--- a/src/components/Template/Question/index.tsx
+++ b/src/components/Template/Question/index.tsx
@@ -3,17 +3,12 @@ import { useCallback, useContext } from 'react';
 
 import { MainContext } from '@/store';
 import { Questions } from '@/types/question.interface';
+import { CheckedSpecialQuestions } from '@/types/question.interface';
 
 import QuestionContent from './QuestionContent';
 import QuestionFooter from './QuestionFooter';
 import QuestionHeader from './QuestionHeader';
 import QuestionOptionalContent from './QuestionOptionalContent';
-
-type checkedSpecialQuestions = {
-  isPAIN_HSTRY: boolean;
-  isCONDITION: boolean;
-  isPAIN_INTV: boolean;
-};
 
 type QuestionProps = {
   onChange: (
@@ -23,7 +18,7 @@ type QuestionProps = {
   ) => void;
   question: Questions;
   setIsCheckedSpecialQuestions: React.Dispatch<
-    React.SetStateAction<checkedSpecialQuestions>
+    React.SetStateAction<CheckedSpecialQuestions>
   >;
 };
 

--- a/src/components/Template/TemplateContent.tsx
+++ b/src/components/Template/TemplateContent.tsx
@@ -8,18 +8,18 @@ import TemplateSelectedQuestionContainer from './TemplateSelectedQuestionContain
 import TemplateSelections from './TemplateSelections';
 import TemplateSubHeader from './TemplateSubHeader';
 
+type checkedSpecialQuestions = {
+  isPAIN_HSTRY: boolean;
+  isCONDITION: boolean;
+  isPAIN_INTV: boolean;
+};
+
 type TemplateContentProps = {
   currTemplateSubHeader: { title: string; description?: string | undefined };
   setCurrTemplateSubHeader: Dispatch<
     SetStateAction<{ title: string; description: string | undefined }>
   >;
   onChange: (id: string, value: string | Questions[]) => void;
-};
-
-type checkedSpecialQuestions = {
-  isPAIN_HSTRY: boolean;
-  isCONDITION: boolean;
-  isPAIN_INTV: boolean;
 };
 
 export default function TemplateContent({

--- a/src/components/Template/TemplateContent.tsx
+++ b/src/components/Template/TemplateContent.tsx
@@ -2,17 +2,12 @@ import { Dispatch, SetStateAction, useContext, useState } from 'react';
 
 import { MainContext } from '@/store';
 import { Questions } from '@/types/question.interface';
+import { CheckedSpecialQuestions } from '@/types/question.interface';
 
 import TemplateQuestionSelections from './TemplateQuestionSelections';
 import TemplateSelectedQuestionContainer from './TemplateSelectedQuestionContainer';
 import TemplateSelections from './TemplateSelections';
 import TemplateSubHeader from './TemplateSubHeader';
-
-type checkedSpecialQuestions = {
-  isPAIN_HSTRY: boolean;
-  isCONDITION: boolean;
-  isPAIN_INTV: boolean;
-};
 
 type TemplateContentProps = {
   currTemplateSubHeader: { title: string; description?: string | undefined };
@@ -30,7 +25,7 @@ export default function TemplateContent({
   const { selectedTemplateTitle } = useContext(MainContext);
 
   const [isCheckedSpecialQuestions, setIsCheckedSpecialQuestions] =
-    useState<checkedSpecialQuestions>({
+    useState<CheckedSpecialQuestions>({
       isPAIN_HSTRY: false,
       isCONDITION: false,
       isPAIN_INTV: false,

--- a/src/components/Template/TemplateQuestionSelections.tsx
+++ b/src/components/Template/TemplateQuestionSelections.tsx
@@ -9,19 +9,14 @@ import PainQuestion from '@/assets/PainQuestion.svg';
 import Selections from '@/assets/Selections.svg';
 import Text from '@/assets/Text.svg';
 import { MainContext } from '@/store';
+import { CheckedSpecialQuestions } from '@/types/question.interface';
 
 import QuestionBox from '../Common/QuestionBox';
 
-type checkedSpecialQuestions = {
-  isPAIN_HSTRY: boolean;
-  isCONDITION: boolean;
-  isPAIN_INTV: boolean;
-};
-
 type TemplateQuestionSelectionsProps = {
-  isCheckedSpecialQuestions: checkedSpecialQuestions;
+  isCheckedSpecialQuestions: CheckedSpecialQuestions;
   setIsCheckedSpecialQuestions: React.Dispatch<
-    React.SetStateAction<checkedSpecialQuestions>
+    React.SetStateAction<CheckedSpecialQuestions>
   >;
 };
 

--- a/src/components/Template/TemplateSelectedQuestionContainer.tsx
+++ b/src/components/Template/TemplateSelectedQuestionContainer.tsx
@@ -3,19 +3,14 @@ import { useCallback, useContext, useEffect } from 'react';
 
 import EmptyQuestion from '@/assets/EmptyQuestion.svg';
 import { MainContext } from '@/store';
+import { CheckedSpecialQuestions } from '@/types/question.interface';
 
 import Question from './Question';
 
-type checkedSpecialQuestions = {
-  isPAIN_HSTRY: boolean;
-  isCONDITION: boolean;
-  isPAIN_INTV: boolean;
-};
-
 type TemplateSelectedQuestionContainerProps = {
-  isCheckedSpecialQuestions: checkedSpecialQuestions;
+  isCheckedSpecialQuestions: CheckedSpecialQuestions;
   setIsCheckedSpecialQuestions: React.Dispatch<
-    React.SetStateAction<checkedSpecialQuestions>
+    React.SetStateAction<CheckedSpecialQuestions>
   >;
 };
 

--- a/src/components/Template/index.tsx
+++ b/src/components/Template/index.tsx
@@ -4,19 +4,13 @@ import { mutate } from 'swr';
 import { createTemplate } from '@/apis/Template';
 import { MainContext } from '@/store';
 import { Questions } from '@/types/question.interface';
+import { NewTemplateContent } from '@/types/template.interface';
 import { templateNotificationText } from '@/utils/constants/template';
 import { useRecord } from '@/utils/recordData';
 
 import TemplateContent from './TemplateContent';
 import TemplateFooter from './TemplateFooter';
 import TemplateTitle from './TemplateTitle';
-
-type NewTemplateContent = {
-  questions: Questions[];
-  category?: '' | 'INTERVIEW' | 'TREATMENT' | undefined;
-  title?: string | undefined;
-  description?: string | undefined;
-};
 
 export default function Template() {
   const {

--- a/src/components/UpdateTemplate/UpdateTemplateContent.tsx
+++ b/src/components/UpdateTemplate/UpdateTemplateContent.tsx
@@ -18,6 +18,7 @@ type TemplateContentProps = {
     isMaximum: boolean;
     errorMessage: string;
   };
+
   questionsListHandler: (type: StringQuestionTypes, tagName: string) => void;
   newQuestionContentHandler: (
     order: number,

--- a/src/components/UpdateTemplate/UpdateTemplateTitle.tsx
+++ b/src/components/UpdateTemplate/UpdateTemplateTitle.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import Loading from '@/components/Common/Loading';
 import { useRecordDetail } from '@/utils/recordData';
 
-type UpdateTemplateTitlePropType = {
+type UpdateTemplateTitleProp = {
   id: number;
   isEditing: boolean;
 };
@@ -11,7 +11,7 @@ type UpdateTemplateTitlePropType = {
 export default function UpdateTemplateTitle({
   id,
   isEditing,
-}: UpdateTemplateTitlePropType) {
+}: UpdateTemplateTitleProp) {
   const { recordDetailData } = useRecordDetail(id);
 
   return (

--- a/src/components/UpdateTemplate/index.tsx
+++ b/src/components/UpdateTemplate/index.tsx
@@ -10,7 +10,7 @@ import { UpdateTemplateType } from '@/types/template.interface';
 import { templateNotificationText } from '@/utils/constants/template';
 import { useRecord } from '@/utils/recordData';
 
-type UpdateTemplatePropType = {
+type UpdateTemplateProp = {
   id: number;
   recordDetailData: recordDetailType;
 };
@@ -18,7 +18,7 @@ type UpdateTemplatePropType = {
 export default function UpdateTemplate({
   id,
   recordDetailData,
-}: UpdateTemplatePropType) {
+}: UpdateTemplateProp) {
   const { recordListData, mutate: mutateTitle } = useRecord();
 
   const [currTemplateSubHeader, setCurrTemplateSubHeader] = useState({

--- a/src/components/common/DeleteModal.tsx
+++ b/src/components/common/DeleteModal.tsx
@@ -17,7 +17,7 @@ import { recordListType } from '@/types/recordList.interface';
 import useCategory from '@/utils/categoryData';
 import { useRecord } from '@/utils/recordData';
 
-type DeleteModalPropsType = {
+type DeleteModalProps = {
   id: number | number[];
   setDeleteModalOpen: Dispatch<SetStateAction<boolean>>;
   title: string;
@@ -33,7 +33,7 @@ export default function DeleteModal({
   setDeleteModalOpen,
   categoryId,
   setIsDeleteMode,
-}: DeleteModalPropsType) {
+}: DeleteModalProps) {
   const { pathname } = useLocation();
 
   const { selectedIds, setSelectedIds } = useContext(MainContext);

--- a/src/components/common/DeleteModal.tsx
+++ b/src/components/common/DeleteModal.tsx
@@ -17,7 +17,7 @@ import {
 import { recordListType } from '@/types/recordList.interface';
 import useCategory from '@/utils/categoryData';
 
-type DeleteModalPropsType = {
+type DeleteModalProps = {
   id: number | number[];
   setDeleteModalOpen: Dispatch<SetStateAction<boolean>>;
   title: string;
@@ -33,7 +33,7 @@ export default function DeleteModal({
   setDeleteModalOpen,
   categoryId,
   setIsDeleteMode,
-}: DeleteModalPropsType) {
+}: DeleteModalProps) {
   const { pathname } = useLocation();
 
   const { selectedIds, setSelectedIds } = useContext(MainContext);

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -6,7 +6,6 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { onSlientRefresh } from '@/apis/Login';
 import Logo from '@/assets/Logo.svg';
 import { category, userName } from '@/utils/constants/header';
-import { categoryType } from '@/utils/constants/header';
 
 export default function Header() {
   const navigate = useNavigate();
@@ -14,7 +13,7 @@ export default function Header() {
   const [clickedIdNum, setClickedIdNum] = useState<number>(2);
 
   const handlePageMove = useCallback(
-    (item: categoryType) => {
+    (item: category) => {
       if (item.id === 2 || item.id === 3) {
         navigate(`${item.name}`);
         setClickedIdNum(item.id);

--- a/src/components/media/MediaCategorySelector.tsx
+++ b/src/components/media/MediaCategorySelector.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import useCategory from '@/utils/categoryData';
 import useMediaList from '@/utils/mediaListData';
 
-type MediaCategorySelectorPropsType = {
+type MediaCategorySelectorProps = {
   selectedCategory: string;
   categoryChange: (title: string) => void;
 };
@@ -12,7 +12,7 @@ type MediaCategorySelectorPropsType = {
 export default function MediaCategorySelector({
   selectedCategory,
   categoryChange,
-}: MediaCategorySelectorPropsType) {
+}: MediaCategorySelectorProps) {
   const { categoryListData, isLoading, error } = useCategory();
   const { totalLinksCount } = useMediaList();
   const navigate = useNavigate();

--- a/src/components/media/MediaListContainer.tsx
+++ b/src/components/media/MediaListContainer.tsx
@@ -10,13 +10,13 @@ import { getLinkUrlInfo } from '@/utils/validations/linkUtils';
 
 import Loading from '../Common/Loading';
 
-type MediaListContainerPropType = {
+type MediaListContainerProp = {
   selectedCategory: string;
 };
 
 export default function MediaListContainer({
   selectedCategory,
-}: MediaListContainerPropType) {
+}: MediaListContainerProp) {
   const { mediaList, isLoading, error } = useMediaList(selectedCategory);
   const [activeMediaCardInfo, setActiveMediaCardInfo] = useState<number>(0);
 

--- a/src/components/record/RecordCard.tsx
+++ b/src/components/record/RecordCard.tsx
@@ -10,12 +10,12 @@ import { MainContext } from '@/store';
 
 import DeleteModal from '../Common/DeleteModal';
 
-type RecordCardPropsType = {
+type RecordCardProps = {
   title: string;
   id: number;
 };
 
-export default function RecordCard({ title, id }: RecordCardPropsType) {
+export default function RecordCard({ title, id }: RecordCardProps) {
   const [isSmallScreen] = useMediaQuery('(min-height: 800px)');
   const { setSeletedRecordCardId, setIsRecordEdit } = useContext(MainContext);
   const [recordTemplateOpen, setRecordTemplateOpen] = useState(false);

--- a/src/components/record/RecordListContainer.tsx
+++ b/src/components/record/RecordListContainer.tsx
@@ -5,13 +5,13 @@ import Loading from '@/components/Common/Loading';
 import RecordCard from '@/components/Record/RecordCard';
 import { useRecord } from '@/utils/recordData';
 
-type RecordListContainerPropsType = {
+type RecordListContainerProps = {
   category: string;
 };
 
 export default function RecordListContainer({
   category,
-}: RecordListContainerPropsType) {
+}: RecordListContainerProps) {
   const { recordListData, isLoading, error } = useRecord(category);
   const [isShowLoading, setIsShowLoading] = useState(false);
 

--- a/src/components/record/RecordModalHeader.tsx
+++ b/src/components/record/RecordModalHeader.tsx
@@ -1,13 +1,13 @@
 import styled from '@emotion/styled';
 
 import Loading from '@/components/Common/Loading';
-import useRecordDetail from '@/hooks/useRecordDetail';
+import { useRecordDetail } from '@/utils/recordData';
 
-type RecordModalHeaderPropType = {
+type RecordModalHeaderProp = {
   id: number;
 };
 
-export default function RecordModalHeader({ id }: RecordModalHeaderPropType) {
+export default function RecordModalHeader({ id }: RecordModalHeaderProp) {
   const { recordDetailData } = useRecordDetail(id);
 
   return (

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -1,6 +1,6 @@
 import React, { Dispatch, SetStateAction, useState } from 'react';
 
-import { categoryListType } from '@/components/Category/CategoryListContents';
+import { categoryList } from '@/components/Category/CategoryListContents';
 import { Questions } from '@/types/question.interface';
 import {
   recordDetailType,
@@ -15,7 +15,7 @@ type ContextType = {
   questionList: Questions[];
   questions: Questions | undefined;
   setQuestions: Dispatch<SetStateAction<Questions | undefined>>;
-  storedCategoryList: categoryListType[] | undefined;
+  storedCategoryList: categoryList[] | undefined;
   selectedRecordCardId: number;
   isRecordEdit: boolean;
   setRecordModalState: Dispatch<SetStateAction<boolean>>;
@@ -23,7 +23,7 @@ type ContextType = {
   setSelectedTemplateTitle: Dispatch<SetStateAction<string>>;
   setQuestionList: Dispatch<SetStateAction<Questions[]>>;
   setStoredCategoryList: (
-    storedCategoryList: categoryListType[] | undefined
+    storedCategoryList: categoryList[] | undefined
   ) => void;
   selectedRecordCard: recordDetailType | undefined;
   setSelectedRecordCard: React.Dispatch<
@@ -99,7 +99,7 @@ export default function MainContextProvider(props: {
   const [selectedRecordCardId, setSeletedRecordCardId] = useState(0);
 
   const [storedCategoryList, setStoredCategoryList] =
-    useState<categoryListType[]>();
+    useState<categoryList[]>();
   const [selectedIds, setSelectedIds] = useState<number[]>([]);
   const contextValue: ContextType = {
     questionList: storedQuestionList,

--- a/src/types/category.interface.ts
+++ b/src/types/category.interface.ts
@@ -1,14 +1,14 @@
-export interface CategoryRequestDTO {
+export interface CategoryRequest {
   title: string;
   description: string;
 }
 
-export interface CategoryResponseDTO extends CategoryRequestDTO {
+export interface CategoryResponse extends CategoryRequest {
   id: number;
   totalCount: number;
 }
 
-export interface CategoryListResponseDTO {
-  categories: CategoryResponseDTO[];
+export interface CategoryListResponse {
+  categories: CategoryResponse[];
   message: string;
 }

--- a/src/types/question.interface.ts
+++ b/src/types/question.interface.ts
@@ -33,3 +33,9 @@ export type StringQuestionTypes =
   | 'PAIN_HSTRY'
   | 'CONDITION'
   | 'PAIN_INTV';
+
+export type CheckedSpecialQuestions = {
+  isPAIN_HSTRY: boolean;
+  isCONDITION: boolean;
+  isPAIN_INTV: boolean;
+};

--- a/src/types/template.interface.ts
+++ b/src/types/template.interface.ts
@@ -25,3 +25,10 @@ export interface UpdateTemplateType {
 export interface UpdateTemplateResponse {
   message: string;
 }
+
+export type NewTemplateContent = {
+  questions: Questions[];
+  category?: '' | 'INTERVIEW' | 'TREATMENT' | undefined;
+  title?: string | undefined;
+  description?: string | undefined;
+};

--- a/src/types/token.interface.ts
+++ b/src/types/token.interface.ts
@@ -1,4 +1,4 @@
-export interface tokenType {
+export interface token {
   accessToken: string;
   refreshToken: string;
   message: string;

--- a/src/utils/categoryData.ts
+++ b/src/utils/categoryData.ts
@@ -1,14 +1,14 @@
 import useSWR from 'swr';
 
 import { getCategoryList } from '@/apis/Category';
-import { CategoryListResponseDTO } from '@/types/category.interface';
+import { CategoryListResponse } from '@/types/category.interface';
 
 export default function useCategory() {
   const {
     data: categoryList,
     mutate,
     error,
-  } = useSWR<CategoryListResponseDTO, Error>('/getCategory', getCategoryList);
+  } = useSWR<CategoryListResponse, Error>('/getCategory', getCategoryList);
 
   return {
     categoryListData: categoryList,

--- a/src/utils/constants/header.ts
+++ b/src/utils/constants/header.ts
@@ -1,10 +1,10 @@
-export type category = {
+type Category = {
   id: number;
   name: string;
   text: string;
 };
 
-export const category: category[] = [
+export const category: Category[] = [
   { id: 0, name: 'employee', text: '직원관리' },
   { id: 1, name: 'tikect', text: '수강권 관리' },
   { id: 2, name: 'record', text: '기록 관리' },

--- a/src/utils/constants/header.ts
+++ b/src/utils/constants/header.ts
@@ -1,10 +1,10 @@
-export type categoryType = {
+export type category = {
   id: number;
   name: string;
   text: string;
 };
 
-export const category: categoryType[] = [
+export const category: category[] = [
   { id: 0, name: 'employee', text: '직원관리' },
   { id: 1, name: 'tikect', text: '수강권 관리' },
   { id: 2, name: 'record', text: '기록 관리' },


### PR DESCRIPTION
## 💡 이슈 번호

close #137 

## 📖 작업 내용

- [X] 공통 type 분리 및 컨벤션 일괄 적용

## ✅ PR 포인트

- 두 곳 이상에서 사용되는 type을 관심사 별로 묶어 분리했어요.
- `~PropsType, ~Type`으로 지정된 값을 `~Props, ~`로 변경했어요.

## 📸 스크린샷
![image](https://github.com/pie-sfac/5-17-smokedDuck/assets/33304871/288e6b46-be4d-407e-87c5-9a23e919bdd9)
