### PR TITLE
fix: 새로고침시에 로딩이 오래 걸리는부분 수정

### DIFF
--- a/src/utils/categoryData.ts
+++ b/src/utils/categoryData.ts
@@ -8,7 +8,13 @@ export default function useCategory() {
     data: categoryList,
     mutate,
     error,
-  } = useSWR<CategoryListResponse, Error>('/getCategory', getCategoryList);
+  } = useSWR<CategoryListResponse, Error>('/getCategory', getCategoryList, {
+    onErrorRetry: (_error, _key, _config, revalidate, { retryCount }) => {
+      setTimeout(() => {
+        revalidate({ retryCount });
+      }, 50);
+    },
+  });
 
   return {
     categoryListData: categoryList,

--- a/src/utils/categoryData.ts
+++ b/src/utils/categoryData.ts
@@ -13,7 +13,7 @@ export default function useCategory() {
       if (retryCount >= 10) return;
       setTimeout(() => {
         revalidate({ retryCount });
-      }, 50);
+      }, 500);
     },
   });
 

--- a/src/utils/categoryData.ts
+++ b/src/utils/categoryData.ts
@@ -10,6 +10,7 @@ export default function useCategory() {
     error,
   } = useSWR<CategoryListResponse, Error>('/getCategory', getCategoryList, {
     onErrorRetry: (_error, _key, _config, revalidate, { retryCount }) => {
+      if (retryCount >= 10) return;
       setTimeout(() => {
         revalidate({ retryCount });
       }, 50);

--- a/src/utils/mediaListData.ts
+++ b/src/utils/mediaListData.ts
@@ -6,7 +6,14 @@ import { GetLinkListResponse } from '@/types/media.interface';
 export default function useMediaList(category?: string) {
   const { data: mediaList, error } = useSWR<GetLinkListResponse, Error>(
     LINK_URL,
-    getLinkList
+    getLinkList,
+    {
+      onErrorRetry: (_error, _key, _config, revalidate, { retryCount }) => {
+        setTimeout(() => {
+          revalidate({ retryCount });
+        }, 50);
+      },
+    }
   );
 
   return {

--- a/src/utils/mediaListData.ts
+++ b/src/utils/mediaListData.ts
@@ -12,7 +12,7 @@ export default function useMediaList(category?: string) {
         if (retryCount >= 10) return;
         setTimeout(() => {
           revalidate({ retryCount });
-        }, 50);
+        }, 500);
       },
     }
   );

--- a/src/utils/mediaListData.ts
+++ b/src/utils/mediaListData.ts
@@ -9,6 +9,7 @@ export default function useMediaList(category?: string) {
     getLinkList,
     {
       onErrorRetry: (_error, _key, _config, revalidate, { retryCount }) => {
+        if (retryCount >= 10) return;
         setTimeout(() => {
           revalidate({ retryCount });
         }, 50);

--- a/src/utils/recordData.ts
+++ b/src/utils/recordData.ts
@@ -1,6 +1,6 @@
 import useSWR from 'swr';
 
-import { recordDetailFetcher, recordListFetcher } from '@/apis/record';
+import { recordDetailFetcher, recordListFetcher } from '@/apis/Record';
 import { recordDetailType } from '@/types/recordDetail.interface';
 import { recordListType } from '@/types/recordList.interface';
 
@@ -9,7 +9,13 @@ export function useRecord(category?: string) {
     data: recordList,
     mutate,
     error,
-  } = useSWR<recordListType, Error>('record-templates', recordListFetcher);
+  } = useSWR<recordListType, Error>('record-templates', recordListFetcher, {
+    onErrorRetry: (_error, _key, _config, revalidate, { retryCount }) => {
+      setTimeout(() => {
+        revalidate({ retryCount });
+      }, 50);
+    },
+  });
 
   const interviewCount = recordList?.filter(
     item => item.category === 'INTERVIEW'

--- a/src/utils/recordData.ts
+++ b/src/utils/recordData.ts
@@ -11,6 +11,7 @@ export function useRecord(category?: string) {
     error,
   } = useSWR<recordListType, Error>('record-templates', recordListFetcher, {
     onErrorRetry: (_error, _key, _config, revalidate, { retryCount }) => {
+      if (retryCount >= 10) return;
       setTimeout(() => {
         revalidate({ retryCount });
       }, 50);

--- a/src/utils/recordData.ts
+++ b/src/utils/recordData.ts
@@ -14,7 +14,7 @@ export function useRecord(category?: string) {
       if (retryCount >= 10) return;
       setTimeout(() => {
         revalidate({ retryCount });
-      }, 50);
+      }, 500);
     },
   });
 


### PR DESCRIPTION
## 💡 이슈 번호

close #145 

## 📖 작업 내용

- [x] 새로고침하면 토큰이 없는 상태로 api 요청을 보내서 에러가 뜨는데 에러뜨면 50ms 안에 다시 요청을 보냄
- [x] retry 횟수는 10번으로 제한

## ✅ PR 포인트
로딩을 새로 해야해서 화면이 깜빡이는데 그냥 로딩창을 한번 보여주고 갈지 아니면 그냥 둘지 봐주세요
## 📸 스크린샷
![PieHealthcare - Chrome 2023-08-10 16-45-59](https://github.com/pie-sfac/5-17-smokedDuck/assets/104823768/c08fe663-782b-4738-a4a7-06799db6e8ff)
